### PR TITLE
Added several new features I needed to openapi3

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -196,6 +196,19 @@ class ObjectBase(object):
         return ret
 
     @classmethod
+    def key_contained(cls, key, target_list):
+        """
+        Returns whether the key is contained in the given list or not.
+        We use this specific function as to prevent usage of keywords we add "_"
+        to several parameters, and we still want to validate those parameters
+        """
+        if key.endswith("_"):
+            extra_key = key[:-1]
+        else:
+            extra_key = key + "_"
+        return key in target_list or extra_key in target_list
+
+    @classmethod
     def can_parse(cls, dct):
         """
         Returns True if this class can parse the given dict.  This is based on
@@ -222,13 +235,13 @@ class ObjectBase(object):
                 # ignore spec extensions
                 continue
 
-            if key not in cls.__slots__:
+            if not cls.key_contained(key, cls.__slots__):
                 # it has something we don't - probably not a match
                 return False
 
         # then, ensure that all required fields are present
         for key in cls.required_fields:
-            if key not in dct:
+            if not cls.key_contained(key, dct):
                 # it doesn't have everything we need - probably not a match
                 return False
 

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -199,7 +199,8 @@ class Operation(ObjectBase):
         else:
             raise NotImplementedError()
 
-    def request(self, base_url, security={}, data=None, parameters={}, verify=True):
+    def request(self, base_url, security={}, data=None, parameters={}, verify=True,
+                session=None):
         """
         Sends an HTTP request as described by this Path
 
@@ -216,6 +217,8 @@ class Operation(ObjectBase):
         :param verify: Should we do an ssl verification on the request or not,
                        In case str was provided, will use that as the CA.
         :type verify: bool/str
+        :param session: a persistent request session
+        :type session: None, requests.Session
         """
         # Set request method (e.g. 'GET')
         self._request = requests.Request(self.path[-1])

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -199,7 +199,7 @@ class Operation(ObjectBase):
         else:
             raise NotImplementedError()
 
-    def request(self, base_url, security={}, data=None, parameters={}):
+    def request(self, base_url, security={}, data=None, parameters={}, verify=True):
         """
         Sends an HTTP request as described by this Path
 
@@ -211,6 +211,11 @@ class Operation(ObjectBase):
         :type security: dict{str: str}
         :param data: The request body to send.
         :type data: any, should match content/type
+        :param parameters: The parameters used to create the path
+        :type parameters: dict{str: str}
+        :param verify: Should we do an ssl verification on the request or not,
+                       In case str was provided, will use that as the CA.
+        :type verify: bool/str
         """
         # Set request method (e.g. 'GET')
         self._request = requests.Request(self.path[-1])

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -200,7 +200,7 @@ class Operation(ObjectBase):
             raise NotImplementedError()
 
     def request(self, base_url, security={}, data=None, parameters={}, verify=True,
-                session=None):
+                session=None, raw_response=False):
         """
         Sends an HTTP request as described by this Path
 
@@ -219,6 +219,9 @@ class Operation(ObjectBase):
         :type verify: bool/str
         :param session: a persistent request session
         :type session: None, requests.Session
+        :param raw_response: If true, return the raw response instead of validating
+                             and exterpolating it.
+        :type raw_response: bool
         """
         # Set request method (e.g. 'GET')
         self._request = requests.Request(self.path[-1])


### PR DESCRIPTION
Features added:
- Cancel ssl verification if requested
- Use session if requested (to perserve cookies, for instance)
- Added the feature of "raw_response" to the request process to address empty responses or responses that are too complicated for the current version of openapi3 code (like those that are based on "allOf")

bug fixes:
- Fixed the lookup of "in_" as it made some stuff fail.
- Added boolean to the types in the lookup so if type is boolean it'll know how to handle it
- Fixed the bug that in case the path held more than one parameter in it, the code would crash.