### PR TITLE
Added possibility to have array of objects in Request

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -184,7 +184,7 @@ class Operation(ObjectBase):
 
     def _request_handle_body(self, data):
         if 'application/json' in self.requestBody.content:
-            if isinstance(data, dict):
+            if isinstance(data, dict) or isinstance(data, list):
                 body = json.dumps(data)
 
             if issubclass(type(data), Model):


### PR DESCRIPTION
For specifications where the requestBody schema type is an array it was throwing errors. Fix was introduced to support these as well.