### PR TITLE
Add support for unicode in python2

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -1,4 +1,14 @@
+import sys
+
 from .errors import SpecError, ReferenceResolutionError
+
+IS_PYTHON_2 = False
+if sys.version_info[0] == 2:
+    IS_PYTHON_2 = True
+else:
+    # unicode was removed in python3, but we need to support both here, so define
+    # it in python 3 only
+    unicode = str
 
 
 class ObjectBase(object):
@@ -136,6 +146,14 @@ class ObjectBase(object):
                 if not isinstance(object_types, list):
                     # maybe don't accept not-lists
                     object_types = [object_types]
+
+                # in python2, some strings might come in as unicode if they have
+                # unicode-only characters in them.  This should allow us to accept
+                # them just as we would in python3
+                if IS_PYTHON_2:
+                    if str in object_types:
+                        object_types += [unicode]
+
 
                 if is_list:
                     if not isinstance(ret, list):

--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -147,7 +147,7 @@ class ObjectBase(object):
                     # maybe don't accept not-lists
                     object_types = [object_types]
 
-                # if yaml loads a value that includes a unicode character in pyton2,
+                # if yaml loads a value that includes a unicode character in python2,
                 # that value will come in as a ``unicode`` type instead of a ``str``.
                 # For the purposes of this library, those are the same thing, so in
                 # python2 only, we'll include ``unicode`` for any element that

--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -147,9 +147,11 @@ class ObjectBase(object):
                     # maybe don't accept not-lists
                     object_types = [object_types]
 
-                # in python2, some strings might come in as unicode if they have
-                # unicode-only characters in them.  This should allow us to accept
-                # them just as we would in python3
+                # if yaml loads a value that includes a unicode character in pyton2,
+                # that value will come in as a ``unicode`` type instead of a ``str``.
+                # For the purposes of this library, those are the same thing, so in
+                # python2 only, we'll include ``unicode`` for any element that
+                # accepts ``str`` types.
                 if IS_PYTHON_2:
                     if str in object_types:
                         object_types += [unicode]


### PR DESCRIPTION
I know that python2 is end of life, and has been for a little while, but
unfortunately I still need to support it.  As such, this allows unicode
strings in specs to pass validation for `str` types without having to
litter the codebase with references to `unicode`.