### PR TITLE
Fix error message formatting.

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -290,7 +290,7 @@ class Operation(ObjectBase):
                          (expected one of {})'''
             err_var = result.headers['Content-Type'], self.operationId, ','.join(expected_response.content.keys())
 
-            raise RuntimeError(err_msg.format(err_var))
+            raise RuntimeError(err_msg.format(*err_var))
 
         response_data = None
 


### PR DESCRIPTION
Without this, we end up getting an error like this on a content type mismatch, since `err_var` is a tuple, it needs to be arg-expanded into `.format`: 

```
Traceback (most recent call last):
  ...
  File "/path/to/3.7.6/lib/python3.7/site-packages/openapi3/openapi.py", line 189, in __call__
    return self.operation(self.base_url, *args, security=self.security,
  File "/path/to/3.7.6/lib/python3.7/site-packages/openapi3/paths.py", line 282, in request
    raise RuntimeError(err_msg.format(err_var))
IndexError: tuple index out of range
```