### PR TITLE
Fallback to root security if not defined for a path.

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -114,7 +114,7 @@ class Operation(ObjectBase):
 
         # TODO - maybe make this generic
         if self.security is None:
-            self.security = []
+            self.security = self._root._get('security',  ['SecurityRequirement'], is_list=True)
 
         if self.parameters is None:
             self.parameters = []


### PR DESCRIPTION
As per [OpenAPI docs](https://swagger.io/docs/specification/authentication/#how), use the default global `security:` if one is not defined on a given path.