### PR TITLE
Add support for resolving allOf attributes

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -449,6 +449,30 @@ class ObjectBase(object):
 
                 setattr(self, slot, resolved_list)
 
+    def _resolve_allOfs(self):
+        """
+        Walks object tree calling _resolve_allOf on each type.
+
+        Types can override this to handle allOf handling themselves.  Types that
+        do so should call the parent class' _resolve_allOf when they do
+        """
+        for slot in self.__slots__:
+            if slot.startswith("_"):
+                # no need to handle private members
+                continue
+
+            value = getattr(self, slot)
+
+            if issubclass(type(value), ObjectBase):
+                value._resolve_allOfs()
+            elif issubclass(type(value), Map):
+                for _, c in value.items():
+                    c._resolve_allOfs()
+            elif isinstance(value, list):
+                for c in value:
+                    if issubclass(type(c), ObjectBase) or issubclass(type(c), Map):
+                        c._resolve_allOfs()
+
 
 class Map(dict):
     """

--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -138,6 +138,7 @@ class OpenAPI(ObjectBase):
 
         # now that we've parsed _all_ the data, resolve all references
         self._resolve_references()
+        self._resolve_allOfs()
 
     def _get_callable(self, operation):
         """

--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -152,7 +152,7 @@ class Schema(ObjectBase):
 
     def _merge(self, other):
         """
-        Merges this Schema with the other, preferring the other schema's values
+        Merges ``other`` into this schema, preferring to use the values in ``other``
         """
         for slot in self.__slots__:
             if slot.startswith("_"):

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -29,22 +29,16 @@ def test_ref_resolution(petstore_expanded_spec):
     assert message.type == 'string'
 
 
-@pytest.mark.skip("This feature isn't merged yet")
 def test_allOf_resolution(petstore_expanded_spec):
     """
     Tests that allOfs are resolved correctly
     """
-    ref = petstore_exapnded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
+    ref = petstore_expanded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
     ref = petstore_expanded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
 
     assert type(ref) == Schema
-    assert ref.type == "object"
-    assert ref.required == ["id","name"]
-    assert len(ref.properties) == 3
-    assert 'id' in ref.properties
-    assert 'name' in ref.properties
-    assert 'tag' in ref.properties
     assert ref.type == "array"
+    assert ref.items is not None
 
     items = ref.items
     assert type(items) == Schema
@@ -54,15 +48,15 @@ def test_allOf_resolution(petstore_expanded_spec):
     assert 'name' in items.properties
     assert 'tag' in items.properties
 
-    id_prop = ref.properties['id']
+    id_prop = items.properties['id']
     id_prop = items.properties['id']
     assert id_prop.type == "integer"
     assert id_prop.format == "int64"
 
-    name = ref.properties['name']
+    name = items.properties['name']
     name = items.properties['name']
     assert name.type == 'string'
 
-    tag = ref.properties['tag']
+    tag = items.properties['tag']
     tag = items.properties['tag']
     assert tag.type == 'string'


### PR DESCRIPTION
The allOf construct is described in the spec [here](http://spec.openapis.org/oas/v3.0.3#composition-and-inheritance-polymorphism)
and further [here](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.2.1.1).

This change allows for schema composition using the allOf construct.
A schema that defines `allOf` will have all of its attributes merged in
from each schema in the `allOf` in sequence, starting with its default
schema and favoring the schema being merged into it.  For example:

```
components:
  schemas:
    Example:
      type: object
      properties:
        foo:
          type: string
          description: Example property
    Example2:
      allOf:
      - $ref: "#/components/schemas/Example"
      properties:
        foo:
          example: bar
```

Would result in a Schema object with a type of "object" and one
property, "foo" whose type is "string", description is "Example
property" and example is "bar".