### PR TITLE
Allow OpenAPI objects to be pickled

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -60,15 +60,33 @@ class ObjectBase(object):
         Returns a string representation of the parsed object
         """
         # TODO - why?
-        return str(self.__dict__())  # pylint: disable=not-callable
+        return "<{} {}>".format(type(self), self.path)
 
     def __dict__(self):
         """
         Returns this object as a dict, removing all empty keys.  This can be used
         to serialize a spec.
         """
-        return {k: getattr(self, k) for k in type(self).__slots__
+        d = {k: getattr(self, k) for k in type(self).__slots__
                 if getattr(self, k) is not None}
+        for k, v in d.items():
+            if hasattr(v, "__dict__"):
+                d[k] = v.__dict__()
+
+        return d
+
+    def __getstate__(self):
+        """
+        Allows pickling objects by returning a dict of all slotted values
+        """
+        return self.__dict__()
+
+    def __setstate__(self, state):
+        """
+        Allows unpickling objects
+        """
+        for k, v in state.items():
+            setattr(self, k, v)
 
     def _required_fields(self, *fields):
         """


### PR DESCRIPTION
This is mostly for the Linode CLI.

Since OpenAPI objects use `__slots__`, they need to define their own
pickling protocol.  This change defined `__getstate__` and
`__setstate__`, which is used internally to pickle/unpickle objects.