### PR TITLE
Added a simple test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 install:
   - pip install pylint requests PyYAML pytest
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install pylint requests PyYAML
+  - pip install pylint requests PyYAML pytest
 script:
+  - pytest
   - pylint openapi

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,13 @@ HTTP basic authentication and HTTP digest authentication works like this::
    # Tuple with (username, password) as second argument
    api.authenticate('basicAuth', ('username', 'password'))
 
+Running Tests
+-------------
+
+This project includes a test suite, run via ``pytest``.  To run the test suite,
+ensure that you've installed the dependencies and then run ``pytest`` in the root
+of this project.
+
 Roadmap
 -------
 
@@ -75,3 +82,4 @@ The following features are planned for the future:
 
 .. _OpenAPI 3 Specification: https://openapis.org
 .. _Linode's OpenAPI 3 Specification: https://developers.linode.com/api/v4
+

--- a/openapi3/__init__.py
+++ b/openapi3/__init__.py
@@ -4,4 +4,4 @@ from .openapi import OpenAPI
 from . import info, servers, paths, general, schemas, components, security, tag, example
 from .errors import SpecError, ReferenceResolutionError
 
-__all__ = ['OpenAPI', 'SpecError', 'ReferenceResolvutionError']
+__all__ = ['OpenAPI', 'SpecError', 'ReferenceResolutionError']

--- a/openapi3/__init__.py
+++ b/openapi3/__init__.py
@@ -2,5 +2,6 @@ from .openapi import OpenAPI
 # these imports appear unused, but in fact load up the subclasses ObjectBase so
 # that they may be referenced throughout the schema without issue
 from . import info, servers, paths, general, schemas, components, security, tag, example
+from .errors import SpecError, ReferenceResolutionError
 
-__all__ = ['OpenAPI']
+__all__ = ['OpenAPI', 'SpecError', 'ReferenceResolvutionError']

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setup(
     packages=['openapi3'],
     license="BSD 3-Clause License",
     install_requires=["PyYaml", "requests"],
+    tests_require=["pytest"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,75 @@
+import pytest
+from yaml import safe_load
+
+from openapi3 import OpenAPI
+
+LOADED_FILES = {}
+
+
+def _get_parsed_yaml(filename):
+    """
+    Returns a python dict that is a parsed yaml file from the tests/fixtures
+    directory.
+
+    :param filename: The filename to load.  Must exist in tests/fixtures and
+                     include extension.
+    :type filename: str
+    """
+    if filename  not in LOADED_FILES:
+        with open("tests/fixtures/"+filename) as f:
+            raw = f.read()
+        parsed = safe_load(raw)
+
+        LOADED_FILES[filename] = parsed
+
+    return LOADED_FILES[filename]
+
+
+def _get_parsed_spec(filename):
+    """
+    Returns an OpenAPI object loaded from a file in the tests/fixtures directory
+
+    :param filename: The filename to load.  Must exist in tests/fixtures and
+                     include extension.
+    :type filename: str
+    """
+    if "spec:"+filename not in LOADED_FILES:
+        parsed = _get_parsed_yaml(filename)
+
+        spec = OpenAPI(parsed)
+
+        LOADED_FILES["spec:"+filename] = spec
+
+    return LOADED_FILES["spec:"+filename]
+
+
+@pytest.fixture
+def petstore_expanded():
+    """
+    Provides the petstore-expanded.yaml spec
+    """
+    yield _get_parsed_yaml("petstore-expanded.yaml")
+
+
+@pytest.fixture
+def petstore_expanded_spec():
+    """
+    Provides an OpenAPI version of the petstore-expanded.yaml spec
+    """
+    yield _get_parsed_spec("petstore-expanded.yaml")
+
+
+@pytest.fixture
+def broken():
+    """
+    Provides the parsed yaml for a broken spec
+    """
+    yield _get_parsed_yaml("broken.yaml")
+
+
+@pytest.fixture
+def broken_reference():
+    """
+    Provides the parsed yaml for a spec with a broken reference
+    """
+    yield _get_parsed_yaml("broken-ref.yaml")

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,17 @@
+# Test Specifications
+
+These OpenAPI specs are included for test purposes only.
+
+## Examples from OpenAPI repository
+
+The following specifications in this directory are taken from OpenAPI example specifications
+hosted here: https://github.com/OAI/OpenAPI-Specification/tree/master/examples
+
+- petstore-expanded.yaml
+
+These specifications are included under OpenAPI's Apache License 2.0, which can
+be found here: https://github.com/OAI/OpenAPI-Specification/blob/master/LICENSE
+
+These specifications are reproduced here to aid testing, but are not authoritative
+copies - those in the repo linked above should be considered authoritative, and
+these should be able to be updated seamlessly should they change.

--- a/tests/fixtures/broken-ref.yaml
+++ b/tests/fixtures/broken-ref.yaml
@@ -1,0 +1,11 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has a broken $ref in it
+paths:
+  /example:
+    get:
+      operationId: hasBrokenRef
+      responses:
+        '200':
+          $ref: '#/components/responses/Missing'

--- a/tests/fixtures/broken.yaml
+++ b/tests/fixtures/broken.yaml
@@ -1,0 +1,4 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This is broken on purpose

--- a/tests/fixtures/petstore-expanded.yaml
+++ b/tests/fixtures/petstore-expanded.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name  
+      properties:
+        name:
+          type: string
+        tag:
+          type: string    
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -1,0 +1,29 @@
+"""
+Tests parsing specs
+"""
+import pytest
+
+from openapi3 import OpenAPI, SpecError, ReferenceResolutionError
+
+
+def test_parse_from_yaml(petstore_expanded):
+    """
+    Tests that we can parse a valid yaml file
+    """
+    spec = OpenAPI(petstore_expanded)
+
+
+def test_parsing_fails(broken):
+    """
+    Tests that broken specs fail to parse
+    """
+    with pytest.raises(SpecError):
+        spec = OpenAPI(broken)
+
+
+def test_parsing_broken_refernece(broken_reference):
+    """
+    Tests that parsing fails correctly when a reference is broken
+    """
+    with pytest.raises(ReferenceResolutionError):
+        spec = OpenAPI(broken_reference)

--- a/tests/path_test.py
+++ b/tests/path_test.py
@@ -1,0 +1,90 @@
+"""
+This file tests that paths are parsed and populated correctly
+"""
+import pytest
+
+from openapi3 import OpenAPI
+from openapi3.schemas import Schema
+
+
+def test_paths_exist(petstore_expanded_spec):
+    """
+    Tests that paths are parsed correctly
+    """
+    assert '/pets' in petstore_expanded_spec.paths
+    assert '/pets/{id}' in petstore_expanded_spec.paths
+    assert len(petstore_expanded_spec.paths) == 2
+
+def test_operations_exist(petstore_expanded_spec):
+    """
+    Tests that methods are populated as expected in paths
+    """
+    pets_path = petstore_expanded_spec.paths['/pets']
+    assert pets_path.get is not None
+    assert pets_path.post is not None
+    assert pets_path.put is None
+    assert pets_path.delete is None
+
+    pets_id_path = petstore_expanded_spec.paths['/pets/{id}']
+    assert pets_id_path.get is not None
+    assert pets_id_path.post is None
+    assert pets_id_path.put is None
+    assert pets_id_path.delete is not None
+
+
+def test_operation_populated(petstore_expanded_spec):
+    """
+    Tests that operations are populated as expected
+    """
+    op = petstore_expanded_spec.paths['/pets'].get
+
+    # check description and metadata populated correctly
+    assert op.operationId == "findPets"
+    assert op.description.startswith("Returns all pets from the system")
+    assert op.summary is None
+
+    # check parameters populated correctly
+    assert len(op.parameters) == 2
+
+    param1 = op.parameters[0]
+    assert param1.name == "tags"
+    assert param1.in_ == "query"
+    assert param1.description == "tags to filter by"
+    assert param1.required == False
+    assert param1.style == "form"
+    assert param1.schema is not None
+    assert param1.schema.type == "array"
+    assert param1.schema.items.type == "string"
+
+    param2 = op.parameters[1]
+    assert param2.name == "limit"
+    assert param2.in_ == "query"
+    assert param2.description == "maximum number of results to return"
+    assert param2.required == False
+    assert param2.schema is not None
+    assert param2.schema.type == "integer"
+    assert param2.schema.format == "int32"
+
+    # check that responses populated correctly
+    assert '200' in op.responses
+    assert 'default' in op.responses
+    assert len(op.responses) == 2
+
+    resp1 = op.responses['200']
+    assert resp1.description == "pet response"
+    assert len(resp1.content) == 1
+    assert 'application/json' in resp1.content
+    con1 = resp1.content['application/json']
+    assert con1.schema is not None
+    assert con1.schema.type == "array"
+    # we're not going to test that the ref resolved correctly here - that's a separate test
+    assert type(con1.schema.items) == Schema
+
+    resp2 = op.responses['default']
+    assert resp2.description == "unexpected error"
+    assert len(resp2.content) == 1
+    assert 'application/json' in resp2.content
+    con2 = resp2.content['application/json']
+    assert con2.schema is not None
+    # again, test ref resolution elsewhere
+    assert type(con2.schema) == Schema

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -1,0 +1,55 @@
+"""
+This file tests that $ref resolution works as expected, and that
+allOfs are populated as expected as well.
+"""
+import pytest
+
+from openapi3 import OpenAPI
+from openapi3.schemas import Schema
+
+
+def test_ref_resolution(petstore_expanded_spec):
+    """
+    Tests that $refs are resolved as we expect them to be
+    """
+    ref = petstore_expanded_spec.paths['/pets'].get.responses['default'].content['application/json'].schema
+
+    assert type(ref) == Schema
+    assert ref.type == "object"
+    assert len(ref.properties) == 2
+    assert 'code' in ref.properties
+    assert 'message' in ref.properties
+    assert ref.required == ['code','message']
+
+    code = ref.properties['code']
+    assert code.type == 'integer'
+    assert code.format == 'int32'
+
+    message = ref.properties['message']
+    assert message.type == 'string'
+
+
+@pytest.mark.skip("This feature isn't merged yet")
+def test_allOf_resolution(petstore_expanded_spec):
+    """
+    Tests that allOfs are resolved correctly
+    """
+    ref = petstore_exapnded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
+
+    assert type(ref) == Schema
+    assert ref.type == "object"
+    assert ref.required == ["id","name"]
+    assert len(ref.properties) == 3
+    assert 'id' in ref.properties
+    assert 'name' in ref.properties
+    assert 'tag' in ref.properties
+
+    id_prop = ref.properties['id']
+    assert id_prop.type == "integer"
+    assert id_prop.format == "int64"
+
+    name = ref.properties['name']
+    assert name.type == 'string'
+
+    tag = ref.properties['tag']
+    assert tag.type == 'string'

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -35,6 +35,7 @@ def test_allOf_resolution(petstore_expanded_spec):
     Tests that allOfs are resolved correctly
     """
     ref = petstore_exapnded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
+    ref = petstore_expanded_spec.paths['/pets'].get.responses['200'].content['application/json'].schema
 
     assert type(ref) == Schema
     assert ref.type == "object"
@@ -43,13 +44,25 @@ def test_allOf_resolution(petstore_expanded_spec):
     assert 'id' in ref.properties
     assert 'name' in ref.properties
     assert 'tag' in ref.properties
+    assert ref.type == "array"
+
+    items = ref.items
+    assert type(items) == Schema
+    assert sorted(items.required) == sorted(["id","name"])
+    assert len(items.properties) == 3
+    assert 'id' in items.properties
+    assert 'name' in items.properties
+    assert 'tag' in items.properties
 
     id_prop = ref.properties['id']
+    id_prop = items.properties['id']
     assert id_prop.type == "integer"
     assert id_prop.format == "int64"
 
     name = ref.properties['name']
+    name = items.properties['name']
     assert name.type == 'string'
 
     tag = ref.properties['tag']
+    tag = items.properties['tag']
     assert tag.type == 'string'


### PR DESCRIPTION
This isn't that extensive yet, but this change adds a simple test suite
using pytest which verifies that certain parsing operations, resolution
operations, and failure modes occur.

This still needs:

- [x] A few more tests
- [x] To be integrated into travis builds
- [x] To be documented in the README