### PR TITLE
Fix operationIds with spaces when populating operationMap

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -110,7 +110,7 @@ class Operation(ObjectBase):
         # gather all operations into the spec object
         if self.operationId is not None:
             # TODO - how to store without an operationId?
-            formatted_operation_id = self.operationId.format(" ", "_")
+            formatted_operation_id = self.operationId.replace(" ", "_")
             self._root._operation_map[formatted_operation_id] = self
 
         # TODO - maybe make this generic

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -110,7 +110,8 @@ class Operation(ObjectBase):
         # gather all operations into the spec object
         if self.operationId is not None:
             # TODO - how to store without an operationId?
-            self._root._operation_map[self.operationId] = self
+            formatted_operation_id = self.operationId.format(" ", "_")
+            self._root._operation_map[formatted_operation_id] = self
 
         # TODO - maybe make this generic
         if self.security is None:


### PR DESCRIPTION
Right now, if an operationId has spaces in it, there won't be a way to
effectively call it using OpenAPI's `call_{operationId}` dynamic
function (since it would require an invalid function name).

This change replaces spaces with underscores in operationIds when
populating the operation map.  This makes an operationId named "test
operations" called like `spec.call_test_operation`.