### PR TITLE
Call prepared request with env. Variable to Use http proxy

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -253,8 +253,11 @@ class Operation(ObjectBase):
 
         self._request_handle_parameters(parameters)
 
+        # get settings from environment
+        settings = self._session.merge_environment_settings(self._request.url, {}, None, None, None)
+
         # send the prepared request
-        result = self._session.send(self._request.prepare())
+        result = self._session.send(self._request.prepare(), **settings)
 
         # spec enforces these are strings
         status_code = str(result.status_code)


### PR DESCRIPTION
Currently, openapi3 doesn't honor HTTP_PROXY/HTTPS_PROXY environment variable.
and, no another way to set http proxy / ca_bundle in openapi3.

As Described in https://github.com/psf/requests/issues/2807#issuecomment-1462910095 , to honor environment variable,  environment setting dict should be taken from requests.Session.merge_environment_settings , and requests.Session.send should called with it.