### PR TITLE
Configurable Session Factory & Passthrough to Operations

### DIFF
--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -16,7 +16,13 @@ class OpenAPI(ObjectBase):
                  '_spec_errors', '_ssl_verify', '_session']
     required_fields=['openapi','info','paths']
 
-    def __init__(self, raw_document, validate=False, ssl_verify=None, use_session=False):
+    def __init__(
+            self,
+            raw_document,
+            validate=False,
+            ssl_verify=None,
+            use_session=False,
+            session_factory=requests.Session):
         """
         Creates a new OpenAPI document from a loaded spec file.  This is
         overridden here because we need to specify the path in the parent
@@ -49,7 +55,7 @@ class OpenAPI(ObjectBase):
 
         self._session = None
         if use_session:
-            self._session = requests.Session()
+            self._session = session_factory()
 
     # public methods
     def authenticte(self, security_scheme, value):

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -253,8 +253,11 @@ class Operation(ObjectBase):
 
         self._request_handle_parameters(parameters)
 
+        if session is None:
+            session = self._session
+
         # send the prepared request
-        result = self._session.send(self._request.prepare())
+        result = session.send(self._request.prepare())
 
         # spec enforces these are strings
         status_code = str(result.status_code)


### PR DESCRIPTION
While using this library for testing, I've had to modify aspects to enable compatibility with a semi-mocked requests Session proxy. It would be nice to be able to provide a factory for the session at runtime, and have the resulting session passed into Operations.

# Allow custom session factories
d4614bf - 7331206+chrised@users.noreply.github.com

This assists in enabling tests to utilise openapi3 to validate their
local/test endpoints.

# Session passthrough to Operation(s)
2b332da - 7331206+chrised@users.noreply.github.com

If a session is defined at the top level, pass it through to the
Operation class, so that it is used instead of the default session
generated at parse-time.