### PR TITLE
Allow multiple parameters in a path

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -154,6 +154,7 @@ class Operation(ObjectBase):
 
     def _request_handle_parameters(self, parameters={}):
         # Parameters
+        path_parameters = {}
         accepted_parameters = {}
         p = self.parameters + self._root.paths[self.path[-2]].parameters
 
@@ -172,7 +173,10 @@ class Operation(ObjectBase):
                 continue
 
             if spec.in_ == 'path':
-                self._request.url = self._request.url.format(**{name: value})
+                # The string method `format` is incapable of partial updates,
+                # as such we need to collect all the path parameters before
+                # applying them to the format string.
+                path_parameters[name] = value
 
             if spec.in_ == 'query':
                 self._request.params[name]  = value
@@ -182,6 +186,8 @@ class Operation(ObjectBase):
 
             if spec.in_ == 'cookie':
                 self._request.cookies[name] = value
+
+        self._request.url = self._request.url.format(**path_parameters)
 
     def _request_handle_body(self, data):
         if 'application/json' in self.requestBody.content:


### PR DESCRIPTION
Attempting to format a path with multiple parameters (e.g. `/{parent_name}/{identifier}`) causes an error response from `format`, since it will only succeed when it can apply to all format arguments in the string.

# format path variables atomically
6b0d17b - 7331206+chrised@users.noreply.github.com

Python's String format method (`format`) does not allow for partial
operation. Strings must be formatted with all required variables
present.