### PR TITLE
Don't allow duplicate OperationIDs

### DIFF
--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -1,7 +1,7 @@
 import requests
 
 from .object_base import ObjectBase, Map
-from .errors import ReferenceResolutionError
+from .errors import ReferenceResolutionError, SpecError
 
 
 class OpenAPI(ObjectBase):
@@ -121,6 +121,20 @@ class OpenAPI(ObjectBase):
         return self._spec_errors
 
     # private methods
+    def _register_operation(self, operation_id, operation):
+        """
+        Adds an Operation to this spec's _operation_map, raising an error if the
+        OperationId has already been registered.
+
+        :param operation_id: The operation ID to register
+        :type operation_id: str
+        :param operation: The operation to register
+        :type operation: Operation
+        """
+        if operation_id in self._operation_map:
+            raise SpecError("Duplicate operationId {}".format(operation_id), path=operation.path)
+        self._operation_map[operation_id] = operation
+
     def _parse_data(self):
         """
         Implementation of :any:`ObjectBase._parse_data`

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -97,7 +97,7 @@ class Parameter(ObjectBase):
         # required is required and must be True if this parameter is in the path
         if self.in_ == "path" and self.required is not True:
             err_msg = 'Parameter {} must be required since it is in the path'
-            raise SpecError(err_msg.format(self.get_path()))
+            raise SpecError(err_msg.format(self.get_path()), path=self.path)
 
 
 class Operation(ObjectBase):
@@ -134,7 +134,7 @@ class Operation(ObjectBase):
         if self.operationId is not None:
             # TODO - how to store without an operationId?
             formatted_operation_id = self.operationId.replace(" ", "_")
-            self._root._operation_map[formatted_operation_id] = self
+            self._root._register_operation(formatted_operation_id, self)
 
         # TODO - maybe make this generic
         if self.security is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,3 +81,11 @@ def has_bad_parameter_name():
     Provides the parsed yaml for a spec with a bad parameter name
     """
     yield _get_parsed_yaml("bad-parameter-name.yaml")
+
+
+@pytest.fixture
+def dupe_op_id():
+    """
+    A spec with a duplicate operation ID
+    """
+    yield _get_parsed_yaml("dupe-operation-ids.yaml")

--- a/tests/fixtures/dupe-operation-ids.yaml
+++ b/tests/fixtures/dupe-operation-ids.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has a duplicate operationId
+paths:
+  /example:
+    get:
+      operationId: dupe
+      responses:
+        '200':
+          description: The response
+          content:
+            application/json:
+              schema:
+                type: object
+  /example2:
+    get:
+      operationId: dupe
+      responses:
+        '200':
+          description: The response
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -40,7 +40,7 @@ def test_parsing_wrong_parameter_name(has_bad_parameter_name):
 
 def test_parsing_dupe_operation_id(dupe_op_id):
     """
-    Tests taht duplicate operation Ids are an error
+    Tests that duplicate operation Ids are an error
     """
     with pytest.raises(SpecError, match="Duplicate operationId dupe"):
         spec = OpenAPI(dupe_op_id)

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -28,6 +28,7 @@ def test_parsing_broken_refernece(broken_reference):
     with pytest.raises(ReferenceResolutionError):
         spec = OpenAPI(broken_reference)
 
+
 def test_parsing_wrong_parameter_name(has_bad_parameter_name):
     """
     Tests that parsing fails if parameter name for path parameters aren't
@@ -35,3 +36,11 @@ def test_parsing_wrong_parameter_name(has_bad_parameter_name):
     """
     with pytest.raises(SpecError, match="Parameter name not found in path: different"):
         spec = OpenAPI(has_bad_parameter_name)
+
+
+def test_parsing_dupe_operation_id(dupe_op_id):
+    """
+    Tests taht duplicate operation Ids are an error
+    """
+    with pytest.raises(SpecError, match="Duplicate operationId dupe"):
+        spec = OpenAPI(dupe_op_id)


### PR DESCRIPTION
[The OpenaAPI standard says](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#operation-object)
this about operationId

> Unique string used to identify the operation. The id MUST be unique among all operations described in the API.

@displague reported that this library was not enforcing that
restriction.  This change adds a new SpecError case for when  operationIds
are not unique.
