### PR TITLE
Validate that parameters defined as in: path exist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,11 @@ def broken_reference():
     Provides the parsed yaml for a spec with a broken reference
     """
     yield _get_parsed_yaml("broken-ref.yaml")
+
+
+@pytest.fixture
+def has_bad_parameter_name():
+    """
+    Provides the parsed yaml for a spec with a bad parameter name
+    """
+    yield _get_parsed_yaml("bad-parameter-name.yaml")

--- a/tests/fixtures/bad-parameter-name.yaml
+++ b/tests/fixtures/bad-parameter-name.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has a mismatched parameter name.
+paths:
+  /example/{name}:
+    get:
+      parameters:
+      - in: path
+        name: different
+        required: true
+        schema:
+          type: string
+      operationId: example
+      responses:
+        '200':
+          description: Success!
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -27,3 +27,11 @@ def test_parsing_broken_refernece(broken_reference):
     """
     with pytest.raises(ReferenceResolutionError):
         spec = OpenAPI(broken_reference)
+
+def test_parsing_wrong_parameter_name(has_bad_parameter_name):
+    """
+    Tests that parsing fails if parameter name for path parameters aren't
+    actually in the path.
+    """
+    with pytest.raises(SpecError, match="Parameter name not found in path: different"):
+        spec = OpenAPI(has_bad_parameter_name)


### PR DESCRIPTION
[The spec says](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#parameter-locations)
that path parameters must actually be part of the operation's URL.

@displague pointed out that this parser was not enforcing that
requirement.  This change begins raising a new SpecError when this
requirement isn't satisfied.
