### PR TITLE
Fix tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.9"
 install:
   - pip install pylint requests PyYAML pytest
+  - pip install -e .
 script:
   - pytest
   - pylint openapi


### PR DESCRIPTION
It looks like the module should be installed in travis' virtualenv
before running pytest
