### PR TITLE
Expand path parameter regex

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -130,6 +130,10 @@ class Operation(ObjectBase):
         raw_servers       = self._get('servers', list)
         # self.callbacks  = self._get('callbacks', dict) TODO
 
+        # default parameters to an empty list for processing later
+        if self.parameters is None:
+            self.parameters = []
+
         # gather all operations into the spec object
         if self.operationId is not None:
             # TODO - how to store without an operationId?
@@ -139,9 +143,6 @@ class Operation(ObjectBase):
         # TODO - maybe make this generic
         if self.security is None:
             self.security = self._root._get('security',  ['SecurityRequirement'], is_list=True) or []
-
-        if self.parameters is None:
-            self.parameters = []
 
         # Store session object
         self._session = requests.Session()

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -16,7 +16,7 @@ def _validate_parameters(instance):
     """
     Ensures that all parameters for this path are valid
     """
-    allowed_path_parameters = re.findall(r'{([a-zA-Z0-9]+)}', instance.path[1])
+    allowed_path_parameters = re.findall(r'{([a-zA-Z0-9\-\._~]+)}', instance.path[1])
 
     for c in instance.parameters:
         if c.in_ == 'path':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,11 @@ def dupe_op_id():
     A spec with a duplicate operation ID
     """
     yield _get_parsed_yaml("dupe-operation-ids.yaml")
+
+
+@pytest.fixture
+def parameter_with_underscores():
+    """
+    A valid spec with underscores in a path parameter
+    """
+    yield _get_parsed_yaml("parameter-with-underscores.yaml")

--- a/tests/fixtures/parameter-with-underscores.yaml
+++ b/tests/fixtures/parameter-with-underscores.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: test spec
+paths:
+  /test/{parameter_with_underscores}:
+    parameters:
+      - name: parameter_with_underscores
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: test
+      responses:
+        '200':
+          description: test
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -44,3 +44,10 @@ def test_parsing_dupe_operation_id(dupe_op_id):
     """
     with pytest.raises(SpecError, match="Duplicate operationId dupe"):
         spec = OpenAPI(dupe_op_id)
+
+
+def test_parsing_parameter_name_with_underscores(parameter_with_underscores):
+    """
+    Tests that path parameters with underscores in them are accepted
+    """
+    spec = OpenAPI(parameter_with_underscores)


### PR DESCRIPTION
Hello, and thank you for the `openapi3` library!

In 02cab5b3ad0f41dfcacc0362dab5e393240a9301, a change was made to validate that path parameters are actually in the path. I believe the regex used, `{([a-zA-Z0-9]+)}`, is a bit too restrictive. This means that API endpoints which use `_` in the path names fail with `openapi3 1.2.0` but pass with similar OpenAPI validation tools, such as [`openapi-spec-validator`](https://github.com/p1c2u/openapi-spec-validator).

The OpenAPI3 spec is ambiguous as to what characters are allowed in a path parameter name, as https://github.com/OAI/OpenAPI-Specification/issues/2119 describes in detail. Until that question is unanswered, this commit takes a conservative approach by extending the regex to match the "unreserved" characters of RFC 3986.

I've run `pytest` locally which passes. Please let me know if there is something else I should do for this PR, and/or feel free to modify it as needed. Thanks!