### PR TITLE
Enforce required fields for Contact element

### DIFF
--- a/openapi3/info.py
+++ b/openapi3/info.py
@@ -30,6 +30,7 @@ class Contact(ObjectBase):
     .. _here: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#contactObject
     """
     __slots__ = ['name', 'url', 'email']
+    required_fields = ['name', 'url', 'email']
 
     def _parse_data(self):
         """


### PR DESCRIPTION
The [OpenAPI standard](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#contactObject)
requires a Contact object to have all of "name", "url", and "email".
This library was not enforcing those requirements.

This change enforces that all three elements of a Contact field are
required.
