### PR TITLE
Better errors when a single type is required

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -219,9 +219,17 @@ class ObjectBase(object):
                             found_type = True
 
                     if not found_type:
+                        if len(object_types) == 1:
+                            if isinstance(object_types[0], str):
+                                expected_type = ObjectBase.get_object_type(object_types[0])
+                                raise SpecError('Expected {}.{} to be of type {}, with required fields {}'.format(
+                                        self.get_path(), field, object_types[0],
+                                        expected_type.required_fields),
+                                    path=self.path,
+                                    element=self)
                         raise SpecError('Expected {}.{} to be one of [{}], got {}'.format(
-                            self.get_path(), field, ','.join([str(c) for c in object_types]),
-                            type(ret)),
+                                self.get_path(), field, ','.join([str(c) for c in object_types]),
+                                type(ret)),
                             path=self.path,
                             element=self)
         except SpecError as e:

--- a/tests/fixtures/broken.yaml
+++ b/tests/fixtures/broken.yaml
@@ -1,4 +1,4 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.0
   title: This is broken on purpose
+paths:

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -17,7 +17,7 @@ def test_parsing_fails(broken):
     """
     Tests that broken specs fail to parse
     """
-    with pytest.raises(SpecError):
+    with pytest.raises(SpecError, match=r"Expected .info to be of type Info, with required fields \['title', 'version'\]" ):
         spec = OpenAPI(broken)
 
 


### PR DESCRIPTION
In making #45, I noticed the validation error was not helpful, and would
be better if it listed out the required fields in the case that only a
single type is allowed.  The old error is still raised in cases where
there are multiple possibilities for a value, since I can't know which
required fields to display, but in the simple case of one specific type
being needed, we can be more helpful.
