### PR TITLE
new: Added support for contentEncoding and similar fields

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -24,7 +24,8 @@ class Schema(ObjectBase):
                  'allOf', 'oneOf', 'anyOf', 'not', 'items', 'properties',
                  'additionalProperties', 'description', 'format', 'default',
                  'nullable', 'discriminator', 'readOnly', 'writeOnly', 'xml',
-                 'externalDocs', 'example', 'deprecated', '_model_type',
+                 'externalDocs', 'example', 'deprecated', 'contentEncoding',
+                 'contentMediaType', 'contentSchema', '_model_type',
                  '_request_model_type', '_resolved_allOfs']
     required_fields = []
 
@@ -60,6 +61,9 @@ class Schema(ObjectBase):
         self.externalDocs         = self._get('externalDocs', dict)  # 'ExternalDocs'
         self.deprecated           = self._get('deprecated', bool)
         self.example              = self._get('example', "*")
+        self.contentEncoding      = self._get('contentEncoding', str)
+        self.contentMediaType     = self._get('contentMediaType', str)
+        self.contentSchema        = self._get('contentSchema', str)
 
         # TODO - Implement the following properties:
         # self.multipleOf


### PR DESCRIPTION
The `contentEncoding`, `contentMediaType`, and `contentSchema` field are
defined by JSON Schema [here](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-8).
While `contentMediaType` [may be ignored by OpenAPI parsers](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#considerations-for-file-uploads),
its presence should be allowed in case schemas are used by other JSON
Schema applications that are unaware of the OpenAPI context.

This change adds support for all three fields to the Schema type,
allowing schemas that use these fields to pass validation.
