### PR TITLE
Fix calls to super in python2

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -61,7 +61,7 @@ class Path(ObjectBase):
         Overloaded _resolve_references to allow us to verify parameters after
         we've got all references settled.
         """
-        super(__class__, self)._resolve_references()
+        super(self.__class__, self)._resolve_references()
 
         # this will raise if parameters are invalid
         _validate_parameters(self)
@@ -155,7 +155,7 @@ class Operation(ObjectBase):
         Overloaded _resolve_references to allow us to verify parameters after
         we've got all references settled.
         """
-        super(__class__, self)._resolve_references()
+        super(self.__class__, self)._resolve_references()
 
         # this will raise if parameters are invalid
         _validate_parameters(self)


### PR DESCRIPTION
These calls were referencing __class__ instead of self.__class__.
Unfortunately I do still need python2 support
