### PR TITLE
bug: allOfs add additional attributes to referenced schemas

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -200,6 +200,19 @@ class Schema(ObjectBase):
         """
         Merges ``other`` into this schema, preferring to use the values in ``other``
         """
+        # Clone the other object so that we're never merging a referenced object.
+        # This will ensure that an allOf like this:
+        #
+        # allOf:
+        # - $ref: '#/components/schema/Example'
+        # - type: object
+        #   properties:
+        #     foo:
+        #       type string
+        #
+        # Does not add or modify "foo" on components.schemas['Example']
+        other = other._clone()
+
         for slot in self.__slots__:
             if slot.startswith("_"):
                 # skip private members

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,3 +152,12 @@ def with_nested_allof_ref():
     Provides a spec with a $ref under a schema defined in an allOf
     """
     yield _get_parsed_yaml("nested-allOf.yaml")
+
+
+@pytest.fixture
+def with_ref_allof():
+    """
+    Provides a spec that includes a reference to a component schema in and out of
+    an allOf
+    """
+    yield _get_parsed_yaml("ref-allof.yaml")

--- a/tests/fixtures/ref-allof.yaml
+++ b/tests/fixtures/ref-allof.yaml
@@ -1,0 +1,41 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has component schema that is referenced twice, once from an allOf
+paths:
+  /just-example:
+    get:
+      operationId: justExampleRef
+      responses:
+        '200':
+          description: It worked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Example'
+  /allof-example:
+    get:
+      operationId: allOfExample
+      responses:
+        '200':
+          description: It worked
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/Example'
+                - type: object
+                  properties:
+                    bar:
+                      type: string
+                      description: Should only appear in this operation
+                      example: bar
+components:
+  schemas:
+    Example:
+      type: object
+      properties:
+        foo:
+          type: string
+          description: A string
+          example: foo

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -74,3 +74,23 @@ def test_resolving_nested_allof_ref(with_nested_allof_ref):
 
     assert type(schema.properties['data'].items) == Schema
     assert 'bar' in schema.properties['data'].items.properties
+    tag = items.properties['tag']
+    assert tag.type == 'string'
+
+
+def test_ref_allof_handling(with_ref_allof):
+    """
+    Tests that allOfs do not modify the originally loaded value of a $ref they
+    includes (which would cause all references to that schema to be modified)
+    """
+    spec = OpenAPI(with_ref_allof)
+    referenced_schema = spec.components.schemas['Example']
+
+    # this should have only one property; the allOf from 
+    # paths['/allof-example']get.responses['200'].content['application/json'].schema
+    # should not modify the component
+    assert len(referenced_schema.properties) == 1, \
+           "Unexpectedly found {} properties on componenets.schemas['Example']: {}".format(
+                   len(referenced_schema.properties),
+                   ", ".join(referenced_schema.properties.keys()),
+            )

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -74,8 +74,6 @@ def test_resolving_nested_allof_ref(with_nested_allof_ref):
 
     assert type(schema.properties['data'].items) == Schema
     assert 'bar' in schema.properties['data'].items.properties
-    tag = items.properties['tag']
-    assert tag.type == 'string'
 
 
 def test_ref_allof_handling(with_ref_allof):


### PR DESCRIPTION
I found this while working on https://github.com/linode/linode-cli/pull/218

As it happens, a schema fragment like this:

```yaml
paths:
  /example:
    get:
      responses:
        '200':
          content:
            application/json:
              schema:
                allOf:
                  - $ref: '#/components/schema/Something'
                  - type: object
                    properties:
                      new:
                        type: string
```

will incorrectly add the `new` property to the
`components/schemas/Something` schema as it is seen by _all_ references
to it.
