### PR TITLE
bug: $refs are not resolved within schemas defined in allOfs

### DIFF
--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -514,7 +514,7 @@ class ObjectBase(object):
                         resolved_value._original_ref = value
                         resolved_list.append(resolved_value)
                     else:
-                        if issubclass(type(value), ObjectBase) or isinstance(value, Map):
+                        if issubclass(type(item), ObjectBase) or isinstance(item, Map):
                             item._resolve_references()
                         resolved_list.append(item)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,3 +144,11 @@ def with_securityparameters():
     Provides a spec with security parameters
     """
     yield _get_parsed_yaml("with-securityparameters.yaml")
+
+
+@pytest.fixture
+def with_nested_allof_ref():
+    """
+    Provides a spec with a $ref under a schema defined in an allOf
+    """
+    yield _get_parsed_yaml("nested-allOf.yaml")

--- a/tests/fixtures/nested-allOf.yaml
+++ b/tests/fixtures/nested-allOf.yaml
@@ -1,0 +1,38 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has a $ref nested in an allOf
+paths:
+  /example:
+    get:
+      operationId: hasNestedAllOfRef
+      responses:
+        '200':
+          description: Example
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Example'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Data'
+                      other:
+                        $ref: '#/components/schemas/Other'
+components:
+  schemas:
+    Data:
+      type: object
+      properties:
+        bar:
+          type: string
+    Example:
+      type: object
+      properties:
+        foo:
+          type: string
+    Other:
+      type: string

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -60,3 +60,20 @@ def test_allOf_resolution(petstore_expanded_spec):
     tag = items.properties["tag"]
     tag = items.properties["tag"]
     assert tag.type == "string"
+
+
+def test_resolving_nested_allof_ref(with_nested_allof_ref):
+    """
+    Tests that a schema with a $ref nested within a schema defined in an allOf
+    parses correctly
+    """
+    spec = OpenAPI(with_nested_allof_ref)
+
+    schema = spec.paths['/example'].get.responses['200'].content['application/json'].schema
+    assert type(schema.properties['other']) == Schema
+    assert schema.properties['other'].type == str
+
+    assert type(schema.properties['data'].items) == Schema
+    tag = items.properties['tag']
+    tag = items.properties['tag']
+    assert tag.type == 'string'

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -71,9 +71,11 @@ def test_resolving_nested_allof_ref(with_nested_allof_ref):
 
     schema = spec.paths['/example'].get.responses['200'].content['application/json'].schema
     assert type(schema.properties['other']) == Schema
-    assert schema.properties['other'].type == str
+    assert schema.properties['other'].type == 'string'
 
     assert type(schema.properties['data'].items) == Schema
     tag = items.properties['tag']
     tag = items.properties['tag']
     assert tag.type == 'string'
+
+    assert 'bar' in schema.properties['data'].items.properties


### PR DESCRIPTION
I found this while working on https://github.com/linode/linode-cli/pull/218

For a spec fragment like this:

```yaml
schema:
  allOf:
    - $ref: '#/components/schemas/Example'
    - type: object
      properties:
        foo:
          $ref: '#/components/schemas/foo'
        bar:
          type: array
          items:
            $ref: '#/components/schemas/bar'
```

neither of the `$ref`s in the second schema in the allOf will be
resolved (the runtime will see each as a Reference type pointing to the
correct part of the schema).
