### PR TITLE
Handle encodings returned in the Content-type header

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -367,6 +367,12 @@ class Operation(ObjectBase):
             return
 
         content_type = result.headers["Content-Type"]
+        if ';' in content_type:
+            # if the content type that came in included an encoding, we'll ignore
+            # it for now (requests has already parsed it for us) and only look at
+            # the MIME type when determining if an expected content type was returned.
+            content_type = content_type.split(';')[0].strip()
+
         expected_media = expected_response.content.get(content_type, None)
 
         if expected_media is None and "/" in content_type:

--- a/tests/api/main.py
+++ b/tests/api/main.py
@@ -61,8 +61,11 @@ def getPet(pet_id: int = Query(..., alias='petId')) -> Pets:
         if pet_id == v.id:
             return v
     else:
+        # media_type included here is to ensure that content encodings do not break
+        # expected response type handling for requests
         return JSONResponse(status_code=starlette.status.HTTP_404_NOT_FOUND,
-                            content=Error(code=errno.ENOENT, message=f"{pet_id} not found").dict())
+                            content=Error(code=errno.ENOENT, message=f"{pet_id} not found").dict(),
+                            media_type="application/json; utf-8")
 
 
 @app.delete('/pets/{pet_id}',


### PR DESCRIPTION
Closes #64

Python's requests library should handle decoding the response for us
using any encoding information included in the Content-type header, so
we can safely ignore it when checking the response against the expected
response types.
