### PR TITLE
Fixed schemas without properties failing to generate models 

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -128,10 +128,14 @@ class Schema(ObjectBase):
         # this is defined in ObjectBase.__init__ as all slots are
         if self._model_type is None:  # pylint: disable=access-member-before-definition
             type_name = self.title or self.path[-1]
+            # if there are no defined properites for this model, use an empty dict
+            # to allow the model to be set up correctly
+            model_properties = self.properties or {}
+
             self._model_type = type(
                 type_name,
                 (Model,),
-                {"__slots__": self.properties.keys()},  # pylint: disable=attribute-defined-outside-init
+                {"__slots__": model_properties.keys()},  # pylint: disable=attribute-defined-outside-init
             )
 
         return self._model_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,3 +170,11 @@ def with_ref_allof():
     an allOf
     """
     yield _get_parsed_yaml("ref-allof.yaml")
+
+
+@pytest.fixture
+def schema_without_properties():
+    """
+    Provides a spec that includes a schema with no properties defined
+    """
+    yield _get_parsed_yaml("schema-without-properties.yaml")

--- a/tests/fixtures/schema-without-properties.yaml
+++ b/tests/fixtures/schema-without-properties.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Schema with no properties
+servers:
+  - url: http://localhost
+paths:
+  /no-props:
+    get:
+      operationId: noProps
+      responses:
+        '200':
+          description: Response object with no properties
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  example:
+                    type: string
+                  no_properties:
+                    type: object

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -13,3 +13,31 @@ def test_invalid_response(petstore_expanded):
         with pytest.raises(ModelError, match="Schema Pet got unexpected attribute keys {'foo'}") as r:
             api.call_find_pet_by_id(data={}, parameters={"id":1})
             print(r)
+
+
+def test_schema_without_properties(schema_without_properties):
+    """
+    Tests that a response model is generated, and responses parsed correctly, for
+    response schemas without properties
+    """
+    api = OpenAPI(schema_without_properties)
+    resp = MagicMock(
+        status_code=200,
+        headers={
+            "Content-Type":"application/json"
+        },
+        json=lambda: {
+            "example": "it worked",
+            "no_properties": {},
+        }
+    )
+
+    with patch("requests.sessions.Session.send", return_value=resp) as s:
+        result = api.call_noProps()
+
+    assert result.example == "it worked"
+
+    # the schema without properties did get its own named type defined
+    assert type(result.no_properties).__name__ == "no_properties"
+    # and it has no slots
+    assert len(type(result.no_properties).__slots__) == 0


### PR DESCRIPTION
A Schema defined as:

```
example:
  type: object
```

should generate a Model named `example` with no `__slots__`.

This change allows generation of a model as described, and
closes https://github.com/Dorthu/openapi3/issues/70.