### PR TITLE
un-escape ~1 and ~0 in paths, handle integers.

### DIFF
--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -101,12 +101,21 @@ class OpenAPI(ObjectBase):
         node = self
 
         for part in path:
+            part = part.replace('~1','/').replace('~0','~')
             if isinstance(node, Map):
                 if part not in node:  # pylint: disable=unsupported-membership-test
                     err_msg = "Invalid path {} in Reference".format(path)
                     raise ReferenceResolutionError(err_msg)
                 node = node.get(part)
             else:
+                try:
+                    ipart = int(part)
+                except ValueError:
+                    pass
+                else:
+                    if ipart>=0 and ipart<len(node):
+                        node = node[ipart]
+                        continue
                 if not hasattr(node, part):
                     err_msg = "Invalid path {} in Reference".format(path)
                     raise ReferenceResolutionError(err_msg)

--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -103,10 +103,11 @@ class OpenAPI(ObjectBase):
         for part in path:
             part = part.replace('~1','/').replace('~0','~')
             if isinstance(node, Map):
-                if part not in node:  # pylint: disable=unsupported-membership-test
+                try:
+                    node = node[part]
+                except KeyError:
                     err_msg = "Invalid path {} in Reference".format(path)
                     raise ReferenceResolutionError(err_msg)
-                node = node.get(part)
             else:
                 try:
                     ipart = int(part)
@@ -116,10 +117,11 @@ class OpenAPI(ObjectBase):
                     if ipart>=0 and ipart<len(node):
                         node = node[ipart]
                         continue
-                if not hasattr(node, part):
+                try:
+                    node = getattr(node, part)
+                except AttributeError:
                     err_msg = "Invalid path {} in Reference".format(path)
                     raise ReferenceResolutionError(err_msg)
-                node = getattr(node, part)
 
         return node
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,3 +178,11 @@ def schema_without_properties():
     Provides a spec that includes a schema with no properties defined
     """
     yield _get_parsed_yaml("schema-without-properties.yaml")
+
+
+@pytest.fixture
+def rfc_6901():
+    """
+    Provides a spec that includes RFC 6901 escape codes in ref paths
+    """
+    yield _get_parsed_yaml("rfc_6901.yaml")

--- a/tests/fixtures/rfc_6901.yaml
+++ b/tests/fixtures/rfc_6901.yaml
@@ -29,7 +29,7 @@ paths:
                   three:
                     $ref: '#/components/schemas/test~01three'
                   four:
-                    $ref: '#/components/schemas/0/properties/example'
+                    $ref: '#/components/schemas/01/properties/example'
   /parameters-holder:
     parameters:
       - name: example
@@ -68,7 +68,7 @@ components:
       type: array
       items:
         type: string
-    '0':
+    '01':
       description: |
         Tests that paths parsed using integer-like segments are handled correctly.
         This will be referenced as `#/components/schemas/0/properties/example`

--- a/tests/fixtures/rfc_6901.yaml
+++ b/tests/fixtures/rfc_6901.yaml
@@ -1,0 +1,47 @@
+# this schema has refs whose paths include the escaped `~` and `/` characters
+# (escaped as ~0 and ~1 respectively).  This also purposefully includes the ~01
+# escape sequence to ensure parsing ends in `~1` and not `/`
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: RFC 6901 Test
+paths:
+  /ref-test:
+    get:
+      operationId: refTestGet
+      responses:
+        '200':
+          description: Test
+          content:
+            application/json:
+              schema:
+                description: |
+                  References all other fields in components/schemas to ensure all references
+                  are tested.
+                type: object
+                properties:
+                  one:
+                    $ref: '#/components/schemas/test~1one'
+                  two:
+                    $ref: '#/components/schemas/test~0two'
+                  three:
+                    $ref: '#/components/schemas/test~01three'
+components:
+  schemas:
+    test/one:
+      description: |
+        Tests that refs can reference paths with a `/` character; this should be
+        escaped as `#/components/schemas/test~1one`
+      type: string
+    test~two:
+      description: |
+        Tests that refs can reference paths with a `~` character; this should be
+        escaped as `#/components/schemas/test~0two`
+      type: int
+    test~1three:
+      description: |
+        Tests that refs can reference paths with a ~1 sequence in them; this should
+        be escaped as `#/components/schemas/test~01three`
+      type: array
+      items:
+        type: string

--- a/tests/fixtures/rfc_6901.yaml
+++ b/tests/fixtures/rfc_6901.yaml
@@ -7,6 +7,8 @@ info:
   title: RFC 6901 Test
 paths:
   /ref-test:
+    parameters:
+      - $ref: '#/paths/~1parameters-holder/parameters/1'
     get:
       operationId: refTestGet
       responses:
@@ -26,6 +28,27 @@ paths:
                     $ref: '#/components/schemas/test~0two'
                   three:
                     $ref: '#/components/schemas/test~01three'
+                  four:
+                    $ref: '#/components/schemas/0/properties/example'
+  /parameters-holder:
+    parameters:
+      - name: example
+        in: query
+        schema:
+          type: int
+      - name: example2
+        in: query
+        schema:
+          type: int
+    get:
+      operationId: parametersHolderGet
+      responses:
+        '200':
+          description: Placeholder
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   schemas:
     test/one:
@@ -45,3 +68,12 @@ components:
       type: array
       items:
         type: string
+    '0':
+      description: |
+        Tests that paths parsed using integer-like segments are handled correctly.
+        This will be referenced as `#/components/schemas/0/properties/example`
+      type: object
+      properties:
+        example:
+          type: string
+          example: it worked

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -92,3 +92,16 @@ def test_ref_allof_handling(with_ref_allof):
                    len(referenced_schema.properties),
                    ", ".join(referenced_schema.properties.keys()),
             )
+
+def test_ref_6901_refs(rfc_6901):
+    """
+    Tests that RFC 6901 escape codes, such as ~0 and ~1, are pared correctly
+    """
+    spec = OpenAPI(rfc_6901)
+
+    # spec parsed, make sure our refs got the right values
+    response = spec.paths['/ref-test'].get.responses['200'].content['application/json'].schema
+
+    assert response.properties['one'].type == 'string'
+    assert response.properties['two'].type == 'int'
+    assert response.properties['three'].type == 'array'

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -84,7 +84,7 @@ def test_ref_allof_handling(with_ref_allof):
     spec = OpenAPI(with_ref_allof)
     referenced_schema = spec.components.schemas['Example']
 
-    # this should have only one property; the allOf from 
+    # this should have only one property; the allOf from
     # paths['/allof-example']get.responses['200'].content['application/json'].schema
     # should not modify the component
     assert len(referenced_schema.properties) == 1, \
@@ -97,11 +97,21 @@ def test_ref_6901_refs(rfc_6901):
     """
     Tests that RFC 6901 escape codes, such as ~0 and ~1, are pared correctly
     """
-    spec = OpenAPI(rfc_6901)
+    spec = OpenAPI(rfc_6901, validate=True)
+    assert len(spec.errors()) == 0, spec.errors()
 
     # spec parsed, make sure our refs got the right values
-    response = spec.paths['/ref-test'].get.responses['200'].content['application/json'].schema
+    path = spec.paths['/ref-test']
+    response = path.get.responses['200'].content['application/json'].schema
 
     assert response.properties['one'].type == 'string'
     assert response.properties['two'].type == 'int'
     assert response.properties['three'].type == 'array'
+
+    # ensure the integer path components parsed as expected too
+    assert response.properties['four'].type == 'string'
+    assert response.properties['four'].example == 'it worked'
+
+    # ensure integer path parsing does work as expected
+    assert len(path.parameters) == 1
+    assert path.parameters[0].name == 'example2'


### PR DESCRIPTION
Closes #74.