### PR TITLE
bug: Accept "any" type for Example values

### DIFF
--- a/openapi3/example.py
+++ b/openapi3/example.py
@@ -17,5 +17,5 @@ class Example(ObjectBase):
         """
         self.summary = self._get("summary", str)
         self.description = self._get("description", str)
-        self.value = self._get("value", ["Reference", dict, str])  # 'any' type
+        self.value = self._get("value", "*")
         self.externalValue = self._get("externalValue", str)

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -467,7 +467,7 @@ class MediaType(ObjectBase):
         Implementation of :any:`ObjectBase._parse_data`
         """
         self.schema = self._get("schema", ["Schema", "Reference"])
-        self.example = self._get("example", str)  # 'any' type
+        self.example = self._get("example", "*")
         self.examples = self._get("examples", ["Example", "Reference"], is_map=True)
         self.encoding = self._get("encoding", dict)  # Map['Encoding']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,3 +186,11 @@ def rfc_6901():
     Provides a spec that includes RFC 6901 escape codes in ref paths
     """
     yield _get_parsed_yaml("rfc_6901.yaml")
+
+
+@pytest.fixture
+def with_array_example():
+    """
+    Provides a spec that includes arrays as the value of examples
+    """
+    yield _get_parsed_yaml("example_array.yaml")

--- a/tests/fixtures/example_array.yaml
+++ b/tests/fixtures/example_array.yaml
@@ -1,0 +1,41 @@
+# this is a valid spec that contains a schema with an array as the value of an
+# exmaple object
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Examples Array
+paths:
+  /example:
+    get:
+      operationId: exampleArrayGet
+      responses:
+        '200':
+          description: example
+          content:
+            application/json:
+              example:
+                - name: something
+              schema:
+                properties:
+                  name:
+                    type: string
+                    description: example
+                    example: something
+  /examples:
+    get:
+      operationId: examplesArrayGet
+      responses:
+        '200':
+          description: example
+          content:
+            application/json:
+              examples:
+                one:
+                  value:
+                    - name: something
+              schema:
+                properties:
+                  name:
+                    type: string
+                    description: example
+                    example: something

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -132,3 +132,11 @@ def test_securityparameters(with_securityparameters):
     spec = OpenAPI(with_securityparameters, validate=True)
     errors = spec.errors()
     assert len(errors) == 0
+
+
+def test_example_type_array(with_array_example):
+    """
+    Tests that examples, definied as "any" type, accept arrays
+    """
+    spec = OpenAPI(with_array_example, validate=True)
+    assert len(spec.errors()) == 0, spec.errors()


### PR DESCRIPTION
Closes #73

The OpenAPI Standard defines a MediaType.example as [any type](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object),
and similarly for [Example.value](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#example-object).

This library previously did not implement these types in that way,
instead accepting a broad set of types, but not _actually_ any type -
namely, arrays would break since they are handled specially when parsing
the spec.

This change moves to `"*"` as the accepted type, which is handled as the
special-case "any" type when parsing specs.  This results in the
expected behavior.  A test was added to confirm that arrays are accepted
as expected.
