### PR TITLE
bug: Use custom error class for undeclared responses

### DIFF
--- a/openapi3/__init__.py
+++ b/openapi3/__init__.py
@@ -3,6 +3,6 @@ from .openapi import OpenAPI
 # these imports appear unused, but in fact load up the subclasses ObjectBase so
 # that they may be referenced throughout the schema without issue
 from . import info, servers, paths, general, schemas, components, security, tag, example
-from .errors import SpecError, ReferenceResolutionError
+from .errors import SpecError, ReferenceResolutionError, UnexpectedResponseError
 
-__all__ = ["OpenAPI", "SpecError", "ReferenceResolutionError"]
+__all__ = ["OpenAPI", "SpecError", "ReferenceResolutionError", "UnexpectedResponseError"]

--- a/openapi3/errors.py
+++ b/openapi3/errors.py
@@ -39,7 +39,7 @@ class UnexpectedResponseError(RuntimeError):
             "Unexpected response {} from {} (expected one of {}, no default is defined)".format(
                 response.status_code,
                 operation.operationId,
-                ",".join(operation.responses.keys()),
+                ", ".join(operation.responses.keys()),
             ),
         )
 

--- a/openapi3/errors.py
+++ b/openapi3/errors.py
@@ -19,3 +19,34 @@ class ReferenceResolutionError(SpecError):
 
 class ModelError(ValueError):
     """The data supplied to the Model mismatches the models attributes"""
+
+
+class UnexpectedResponseError(RuntimeError):
+    """
+    This error is raised if a call to an Operation results in an undocumented
+    Response Code, and encapsulates the response received as well as the unexpected
+    status code.
+    """
+    def __init__(self, response, operation):
+        """
+        :param response: The response object returned from the request, in full
+        :type response: requests.Response
+        :param operation: The operation object that was making the request
+        :type operation: openapi3.Operation
+        """
+        # set up error message
+        super().__init__(
+            "Unexpected response {} from {} (expected one of {}, no default is defined)".format(
+                response.status_code,
+                operation.operationId,
+                ",".join(operation.responses.keys()),
+            ),
+        )
+
+        #: The full response object returned from the request, of type requests.Response
+        self.response = response
+        #: The Operation object that made the request
+        self.operation = operation
+        #: A convenience field that captures the unexpected status code that
+        #: triggered this exception.
+        self.status_code = response.status_code

--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from urllib import urlencode
 
-from .errors import SpecError
+from .errors import SpecError, UnexpectedResponseError
 from .object_base import ObjectBase
 from .schemas import Model
 
@@ -354,12 +354,7 @@ class Operation(ObjectBase):
             expected_response = self.responses["default"]
 
         if expected_response is None:
-            # TODO - custom exception class that has the response object in it
-            err_msg = """Unexpected response {} from {} (expected one of {}, \
-                         no default is defined"""
-            err_var = result.status_code, self.operationId, ",".join(self.responses.keys())
-
-            raise RuntimeError(err_msg.format(*err_var))
+            raise UnexpectedResponseError(result, self)
 
         # if we got back a valid response code (or there was a default) and no
         # response content was expected, return None

--- a/tests/api/main.py
+++ b/tests/api/main.py
@@ -57,6 +57,13 @@ def listPet(limit: Optional[int] = None) -> Pets:
          }
          )
 def getPet(pet_id: int = Query(..., alias='petId')) -> Pets:
+    if pet_id == -2:
+        # special case - return an unexpected response code
+        return JSONResponse(
+            status_code=starlette.status.HTTP_204_NO_CONTENT,
+        )
+
+    # normal responses
     for k, v in ZOO.items():
         if pet_id == v.id:
             return v

--- a/tests/fastapi_test.py
+++ b/tests/fastapi_test.py
@@ -14,11 +14,13 @@ import openapi3
 
 from api.main import app
 
+
 @pytest.fixture(scope="session")
 def config(unused_tcp_port_factory):
     c = Config()
     c.bind = [f"localhost:{unused_tcp_port_factory()}"]
     return c
+
 
 @pytest.fixture(scope="session")
 def event_loop(request):
@@ -38,6 +40,7 @@ async def server(event_loop, config):
         sd.set()
         await task
 
+
 @pytest.fixture(scope="session")
 async def client(event_loop, server):
     data = await asyncio.to_thread(requests.get, f"http://{server.bind[0]}/openapi.json")
@@ -46,8 +49,10 @@ async def client(event_loop, server):
     api = openapi3.OpenAPI(data)
     return api
 
+
 def randomPet(name=None):
     return {"data":{"pet":{"name":str(name) or random.choice(["dog","cat","mouse","eagle"])}}}
+
 
 @pytest.mark.asyncio
 async def test_createPet(event_loop, server, client):
@@ -64,6 +69,7 @@ async def test_listPet(event_loop, server, client):
     l = await asyncio.to_thread(client.call_listPet)
     assert len(l) > 0
 
+
 @pytest.mark.asyncio
 async def test_getPet(event_loop, server, client):
     pet = await asyncio.to_thread(client.call_createPet, **randomPet(uuid.uuid4()))
@@ -74,9 +80,10 @@ async def test_getPet(event_loop, server, client):
     r = await asyncio.to_thread(client.call_getPet, parameters={"pet_id":-1})
     assert type(r) == client.components.schemas["Error"].get_type()
 
+
 @pytest.mark.asyncio
 async def test_deletePet(event_loop, server, client):
-    r = await asyncio.to_thread(client.call_deletePet, parameters={"pet_id":-1})
+    r = await asyncio.to_thread(client.call_deletePet, parameters={"pet_id":-2})
     assert type(r) == client.components.schemas["Error"].get_type()
 
     await asyncio.to_thread(client.call_createPet, **randomPet(uuid.uuid4()))
@@ -84,3 +91,14 @@ async def test_deletePet(event_loop, server, client):
     for pet in zoo:
         await asyncio.to_thread(client.call_deletePet, parameters={"pet_id":pet.id})
 
+
+@pytest.mark.asyncio
+async def test_getPetUnexpectedResponse(event_loop, server, client):
+    """
+    Tests that undeclared response codes raise the correct UnexpectedResponseError
+    with the relevant inforamtion included.
+    """
+    with pytest.raises(openapi3.UnexpectedResponseError) as exc_info:
+        r = await asyncio.to_thread(client.call_getPet, parameters={"pet_id": -2})
+
+    assert exc_info.value.status_code == 204

--- a/tests/fastapi_test.py
+++ b/tests/fastapi_test.py
@@ -83,7 +83,7 @@ async def test_getPet(event_loop, server, client):
 
 @pytest.mark.asyncio
 async def test_deletePet(event_loop, server, client):
-    r = await asyncio.to_thread(client.call_deletePet, parameters={"pet_id":-2})
+    r = await asyncio.to_thread(client.call_deletePet, parameters={"pet_id":-1})
     assert type(r) == client.components.schemas["Error"].get_type()
 
     await asyncio.to_thread(client.call_createPet, **randomPet(uuid.uuid4()))
@@ -98,7 +98,10 @@ async def test_getPetUnexpectedResponse(event_loop, server, client):
     Tests that undeclared response codes raise the correct UnexpectedResponseError
     with the relevant inforamtion included.
     """
-    with pytest.raises(openapi3.UnexpectedResponseError) as exc_info:
+    with pytest.raises(
+            openapi3.UnexpectedResponseError,
+            match=r"Unexpected response 204 from getPet \(expected one of 200, 404, 422, no default is defined\)",
+        ) as exc_info:
         r = await asyncio.to_thread(client.call_getPet, parameters={"pet_id": -2})
 
     assert exc_info.value.status_code == 204


### PR DESCRIPTION
Closes #80

When this library is used as a client and the server returns a response
that was not declared in the operation's responses, an exception is
raised.  Right now, this is a `RuntimeError` with a message explaining
what code was returned, and that it was undocumented.  This is not
useful when using the client against an API whose documentation you do
not control, and that is missing exhaustive documentation for responses
(generally error responses fall into this category).

This change adds a new error type, `openapi3.UnexpectedResponseError`,
and raises that instead of `RuntimeError`.  In addition to the message,
this error includes the full response that was returned, the operation
that made the call, and the status code that was not expected. This new
error is a subclass of `RuntimeError` to preserve backward
compatibility.
