### PR TITLE
bug: Fields of Contact are not required

### DIFF
--- a/openapi3/info.py
+++ b/openapi3/info.py
@@ -31,7 +31,7 @@ class Contact(ObjectBase):
     """
 
     __slots__ = ["name", "url", "email"]
-    required_fields = ["name", "url", "email"]
+    required_fields = []
 
     def _parse_data(self):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,3 +194,11 @@ def with_array_example():
     Provides a spec that includes arrays as the value of examples
     """
     yield _get_parsed_yaml("example_array.yaml")
+
+
+@pytest.fixture
+def empty_contact():
+    """
+    Provides a spec with an empty contact section in info
+    """
+    yield _get_parsed_yaml("empty_contact.yaml")

--- a/tests/fixtures/empty_contact.yaml
+++ b/tests/fixtures/empty_contact.yaml
@@ -1,0 +1,7 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Valid spec with valid an empty contact block
+  contact:
+    name: Example
+paths:

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -140,3 +140,11 @@ def test_example_type_array(with_array_example):
     """
     spec = OpenAPI(with_array_example, validate=True)
     assert len(spec.errors()) == 0, spec.errors()
+
+
+def test_empty_contact(empty_contact):
+    """
+    Tests that empty contact blocks are accepted
+    """
+    spec = OpenAPI(empty_contact, validate=True)
+    assert len(spec.errors()) == 0


### PR DESCRIPTION
Closes #82

The definition of the [Contact object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#contact-object)
does not list any required fields; these were marked as required my
mistake.
