### PR TITLE
paths: fix Operation request urljoin

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -4,8 +4,10 @@ import requests
 
 try:
     from urllib.parse import urlencode
+    from urllib.parse import urljoin
 except ImportError:
     from urllib import urlencode
+    from urlparse import urljoin
 
 from .errors import SpecError, UnexpectedResponseError
 from .object_base import ObjectBase
@@ -310,7 +312,7 @@ class Operation(ObjectBase):
         self._request = requests.Request(self.path[-1])
 
         # Set self._request.url to base_url w/ path
-        self._request.url = base_url + self.path[-2]
+        self._request.url = urljoin(base_url, self.path[-2])
 
         if security and self.security:
             security_requirement = None


### PR DESCRIPTION
When adding operation `path` to the base_url, the use of the `+` operator can lead to doubling of `/` characters if the base_url ends with a `/`.

Using urljoin should fix this. This is also a cleaner way to work with url paths.

This causes some minor issues for us when interacting with our rest api server where the doubled `/` character is not matched correctly and results in 404 errors.

Even though the doubled `/` characters are defined in RFCs as something that should be simply skipped and don't effectively change the path, some http servers can be configured either way.

An example of a reproducer is to use a schema that looks as follows:
```yaml
openapi: 3.0.2
info:
  title: LNST Dashboard
  version: ''
  description: API to the interact with the dashboard db directly - upload or get
    and process data as you wish
servers:
  - url: https://api.example.com/
paths:
  /artifacts/:
    get:
      operationId: listArtifacts
...
```

vs.
```yaml
```yaml
openapi: 3.0.2
info:
  title: LNST Dashboard
  version: ''
  description: API to the interact with the dashboard db directly - upload or get
    and process data as you wish
servers:
  - url: https://api.example.com
paths:
  /artifacts/:
    get:
      operationId: listArtifacts
...
```

Note that the difference is the final `/` in the server url.

For the first schema with the current code of openapi3 the request `api.call_listArtifacts()` would call:
```
https://api.example.com//artifacts
```

Whereas with the fix the same request would call:
```
https://api.example.com/artifacts
```