### PR TITLE
Support OpenAPI 3.1.0 extended Reference objects

### DIFF
--- a/openapi3/components.py
+++ b/openapi3/components.py
@@ -17,6 +17,7 @@ class Components(ObjectBase):
         "headers",
         "requestBodies",
         "securitySchemes",
+        "pathItems",
         "links",
         "callback",
     ]
@@ -32,5 +33,6 @@ class Components(ObjectBase):
         self.schemas = self._get("schemas", ["Schema", "Reference"], is_map=True)
         self.securitySchemes = self._get("securitySchemes", ["SecurityScheme", "Reference"], is_map=True)
         # self.headers       = self._get('headers', ['Header', 'Reference'], is_map=True)
+        self.pathItems = self._get("pathItems", ['Path', 'Reference'], is_map=True)
         self.links = self._get("links", ["Link", "Reference"], is_map=True)
         # self.callbacks     = self._get('callbacks', ['Callback', 'Reference'], is_map=True)

--- a/openapi3/general.py
+++ b/openapi3/general.py
@@ -25,11 +25,13 @@ class Reference(ObjectBase):
     """
 
     # can't start a variable name with a $
-    __slots__ = ["ref"]
+    __slots__ = ["ref", "summary", "description"]
     required_fields = ["$ref"]
 
     def _parse_data(self):
         self.ref = self._get("$ref", str)
+        self.summary = self._get("summary", str)
+        self.description = self._get("description", str)
 
     @classmethod
     def can_parse(cls, dct):
@@ -38,6 +40,9 @@ class Reference(ObjectBase):
         in __slots__ (since that's not a valid python variable name)
         """
         # TODO - can a reference object have spec extensions?
-        cleaned_keys = [k for k in dct.keys() if not k.startswith("x-")]
+        # summary and description are optional keys; their presence shouldn't
+        # affect what we can and can't parse (so remove them for the purpose of
+        # checking)
+        cleaned_keys = [k for k in dct.keys() if not k.startswith("x-") and k not in ("summary", "description")]
 
         return len(cleaned_keys) == 1 and "$ref" in dct

--- a/openapi3/object_base.py
+++ b/openapi3/object_base.py
@@ -696,10 +696,10 @@ class ReferenceProxy(ObjectBase):
     intents and purposes, it behaves like the object it proxies, except for the
     following:
 
-     * If a "summary" or "description" were set in the Refernce object _and_ the
+     * If a "summary" or "description" were set in the Reference object _and_ the
        proxies object has this attributes, the Reference object's values are used
        instead
-     * This holds the original Refernce object that it is proxying for, allowing
+     * This holds the original Reference object that it is proxying for, allowing
        code to track down the reference
      * Calling `type` on a ReferenceProxy will return the ReferenceProxy type;
        use `type(ref._proxy)` or `isinstance(ref, Type)` to see the proxied type
@@ -731,7 +731,7 @@ class ReferenceProxy(ObjectBase):
         if value in ("_proxy", "_original_ref", "__eq__"):
             return object.__getattribute__(self, value)
 
-        # OpenAPI 3.1.0 allows Reference objects to makes the summary and description
+        # OpenAPI 3.1.0 allows Reference objects to make the summary and description
         # fields of the object they're referencing, but only if they have the field
         # defined _and_ the field exists in the type they're referencing.
         if value in ("summary", "description"):

--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -175,7 +175,7 @@ class OpenAPI(ObjectBase):
         self.externalDocs = self._get("externalDocs", "ExternalDocumentation")
         self.info = self._get("info", "Info")
         self.openapi = self._get("openapi", str)
-        self.paths = self._get("paths", ["Path"], is_map=True)
+        self.paths = self._get("paths", ["Path", "Reference"], is_map=True)
         self.security = self._get("security", ["SecurityRequirement"], is_list=True)
         self.servers = self._get("servers", ["Server"], is_list=True)
         self.tags = self._get("tags", ["Tag"], is_list=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,9 +203,18 @@ def empty_contact():
     """
     yield _get_parsed_yaml("empty_contact.yaml")
 
+
 @pytest.fixture
 def with_external_docs():
     """
     Provides a spec with externalDocs objects in all valid places
     """
     yield _get_parsed_yaml("with-external-docs.yaml")
+
+
+@pytest.fixture
+def with_openapi_310_references():
+    """
+    Provides a spec with OpenAPI 3.1.0 expanded Reference Objects
+    """
+    yield _get_parsed_yaml("openapi-3.1.0-refs.yaml")

--- a/tests/fixtures/openapi-3.1.0-refs.yaml
+++ b/tests/fixtures/openapi-3.1.0-refs.yaml
@@ -1,0 +1,33 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: OpenAPI 3.1.0 Expanded Refernce Objects
+paths:
+  /example:
+    $ref: "#/components/pathItems/example"
+  /other:
+    $ref: "#/components/pathItems/example"
+    summary: /other
+    description: /other
+components:
+  schemas:
+    Example:
+      type: object
+      properties:
+        foo:
+          type: string
+          description: example
+  pathItems:
+    example:
+      summary: /example
+      description: /example
+      get:
+        responses:
+          "200":
+            description: ''
+            content:
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/Example'
+                  summary: Has no effect
+                  description: Has no effect

--- a/tests/fixtures/openapi-3.1.0-refs.yaml
+++ b/tests/fixtures/openapi-3.1.0-refs.yaml
@@ -1,7 +1,7 @@
 openapi: "3.1.0"
 info:
   version: 1.0.0
-  title: OpenAPI 3.1.0 Expanded Refernce Objects
+  title: OpenAPI 3.1.0 Expanded Reference Objects
 paths:
   /example:
     $ref: "#/components/pathItems/example"

--- a/tests/path_test.py
+++ b/tests/path_test.py
@@ -86,7 +86,7 @@ def test_operation_populated(petstore_expanded_spec):
     assert con1.schema is not None
     assert con1.schema.type == "array"
     # we're not going to test that the ref resolved correctly here - that's a separate test
-    assert type(con1.schema.items) == Schema
+    assert isinstance(con1.schema.items, Schema)
 
     resp2 = op.responses["default"]
     assert resp2.description == "unexpected error"
@@ -95,7 +95,7 @@ def test_operation_populated(petstore_expanded_spec):
     con2 = resp2.content["application/json"]
     assert con2.schema is not None
     # again, test ref resolution elsewhere
-    assert type(con2.schema) == Schema
+    assert isinstance(con2.schema, Schema)
 
 
 def test_securityparameters(with_securityparameters):

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -5,7 +5,9 @@ allOfs are populated as expected as well.
 import pytest
 
 from openapi3 import OpenAPI
+from openapi3.object_base import ReferenceProxy
 from openapi3.schemas import Schema
+from openapi3.general import Reference
 
 
 def test_ref_resolution(petstore_expanded_spec):
@@ -14,7 +16,8 @@ def test_ref_resolution(petstore_expanded_spec):
     """
     ref = petstore_expanded_spec.paths["/pets"].get.responses["default"].content["application/json"].schema
 
-    assert type(ref) == Schema
+    assert type(ref) == ReferenceProxy
+    assert type(ref._proxy) == Schema
     assert ref.type == "object"
     assert len(ref.properties) == 2
     assert "code" in ref.properties
@@ -34,14 +37,14 @@ def test_allOf_resolution(petstore_expanded_spec):
     Tests that allOfs are resolved correctly
     """
     ref = petstore_expanded_spec.paths["/pets"].get.responses["200"].content["application/json"].schema
-    ref = petstore_expanded_spec.paths["/pets"].get.responses["200"].content["application/json"].schema
 
     assert type(ref) == Schema
     assert ref.type == "array"
     assert ref.items is not None
 
     items = ref.items
-    assert type(items) == Schema
+    assert type(items) == ReferenceProxy
+    assert type(items._proxy) == Schema
     assert sorted(items.required) == sorted(["id", "name"])
     assert len(items.properties) == 3
     assert "id" in items.properties
@@ -115,3 +118,38 @@ def test_ref_6901_refs(rfc_6901):
     # ensure integer path parsing does work as expected
     assert len(path.parameters) == 1
     assert path.parameters[0].name == 'example2'
+
+
+def test_openapi_3_1_0_references(with_openapi_310_references):
+    """
+    Tests that expanded references, as defined in OpenAPI 3.1.0, work as described
+    """
+    # spec parses with expanded reference objects
+    spec = OpenAPI(with_openapi_310_references)
+
+    # the extended reference to Example did nothing
+    example_ref = spec.components.pathItems["example"].get.responses["200"].content["application/json"]
+    assert not hasattr(example_ref, "summary")
+    assert not hasattr(example_ref, "description")
+
+    # the original definition of the example Path is unchanged
+    original_path = spec.components.pathItems["example"]
+    assert original_path.summary == "/example"
+    assert original_path.description == "/example"
+
+    # the plain reference sees the original object's values
+    normal_ref = spec.paths["/example"]
+    assert normal_ref.summary == "/example"
+    assert normal_ref.description == "/example"
+    assert normal_ref == original_path
+    assert normal_ref._proxy == original_path
+    assert isinstance(normal_ref._original_ref, Reference)
+
+    # the extended reference sees the new values
+    extended_ref = spec.paths["/other"]
+    assert extended_ref.summary == "/other"
+    assert extended_ref.description == "/other"
+    assert extended_ref == original_path
+    assert extended_ref._proxy == original_path
+    assert isinstance(extended_ref._original_ref, Reference)
+    assert extended_ref._original_ref != normal_ref._original_ref


### PR DESCRIPTION
Closes #61

In OpenAPI 3.1.0, the [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object) gained two new attributes, `summary` and `description`.  These attributes are optional, and #61 indicated that they were preventing this library from parsing specs where they were present.

Based on the standard, these fields are ignored unless the referenced type has a like-named field; in that case only, the value in the Reference Object's fields are used in place of that values in the like-named fields of the object it references. For example, in this partial spec:

```yaml
paths:
  /example:
    $ref: '#/components/pathItems/example'
    summary: Override
components:
  pathItems:
    example:
      summary: Original
```

The value of `paths./example.summary` should be `Override`, not the referenced object's value of `Original`.

Along the way, I discovered that I didn't have support of `pathItems` or referencing the `Path` type either, and implementing this override behavior required some fancy proxying of referenced objects to ensure that the original values were not overridden.

The tests pass, and I did some manual testing as well, but I will be seeking review of this change, and will be making it a major release as well.