### PR TITLE
bug: Correctly parse all types for `default`

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -8,6 +8,7 @@ TYPE_LOOKUP = {
     "object": dict,
     "string": str,
     "boolean": bool,
+    "number": float,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,7 @@ def with_external_docs():
 
 
 @pytest.fixture
+
 def with_openapi_310_references():
     """
     Provides a spec with OpenAPI 3.1.0 expanded Reference Objects
@@ -226,3 +227,11 @@ def with_reference_referencing_reference():
     Provides a spec with a reference that references a reference
     """
     yield _get_parsed_yaml("reference-reference-reference.yaml")
+
+
+@pytest.fixture
+def with_all_default_types():
+    """
+    Provides a spec with defaults defined in various schemas of all types
+    """
+    yield _get_parsed_yaml("with_all_default_types.yaml")

--- a/tests/fixtures/with_all_default_types.yaml
+++ b/tests/fixtures/with_all_default_types.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Numeric default parameter
+  version: 0.0.1
+paths:
+  /example:
+    get:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                int:
+                  type: integer
+                  default: 0
+                str:
+                  type: string
+                  default: "test"
+                bool:
+                  type: boolean
+                  default: true
+                float:
+                  type: number
+                  default: 0.1
+        required: true
+      responses:
+        200:
+          description: it worked
+components:
+  parameters:
+    int:
+      name: exampleParam
+      in: query
+      schema:
+        type: integer
+        default: 0
+    str:
+      name: exampleParam2
+      in: query
+      schema:
+        type: string
+        default: "test"
+    bool:
+      name: exampleParam3
+      in: query
+      schema:
+        type: boolean
+        default: true
+    float:
+      name: exampleParam4
+      in: query
+      schema:
+        type: number
+        default: 0.1

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -159,3 +159,20 @@ def test_external_docs(with_external_docs):
     assert spec.tags[0].externalDocs.url == "http://example.org/tags"
     assert spec.paths["/example"].get.externalDocs.url == "http://example.org/operation"
     assert spec.paths["/example"].get.responses['200'].content['application/json'].schema.externalDocs.url == "http://example.org/schema"
+
+
+def test_schema_default_types(with_all_default_types):
+    """
+    Tests that schemas accept defaults in their defined types
+    """
+    spec = OpenAPI(with_all_default_types)
+    assert spec.components.parameters["int"].schema.default == 0
+    assert spec.components.parameters["str"].schema.default == "test"
+    assert spec.components.parameters["bool"].schema.default == True
+    assert spec.components.parameters["float"].schema.default == 0.1
+
+    schema = spec.paths["/example"].get.requestBody.content["application/json"].schema
+    assert schema.properties["int"].default == 0
+    assert schema.properties["str"].default == "test"
+    assert schema.properties["bool"].default == True
+    assert schema.properties["float"].default == 0.1


### PR DESCRIPTION
Closes #91

It looks like I missed the [number type](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#data-types) initially, so floating-point values weren't being parsed correctly.  This change adds support for them, and also adds a test to ensure that all `types` values in a schema can correctly parse their corrosponding `default` value.