### PR TITLE
bug: Resolve references in components first

### DIFF
--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -180,7 +180,9 @@ class OpenAPI(ObjectBase):
         self.servers = self._get("servers", ["Server"], is_list=True)
         self.tags = self._get("tags", ["Tag"], is_list=True)
 
-        # now that we've parsed _all_ the data, resolve all references
+        # now that we've parsed _all_ the data, resolve all references; start with
+        # components so that paths that reference them will see the resolved references
+        self.components._resolve_references()
         self._resolve_references()
         self._resolve_allOfs()
 

--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -182,7 +182,8 @@ class OpenAPI(ObjectBase):
 
         # now that we've parsed _all_ the data, resolve all references; start with
         # components so that paths that reference them will see the resolved references
-        self.components._resolve_references()
+        if self.components is not None:
+            self.components._resolve_references()
         self._resolve_references()
         self._resolve_allOfs()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,3 +218,11 @@ def with_openapi_310_references():
     Provides a spec with OpenAPI 3.1.0 expanded Reference Objects
     """
     yield _get_parsed_yaml("openapi-3.1.0-refs.yaml")
+
+
+@pytest.fixture
+def with_reference_referencing_reference():
+    """
+    Provides a spec with a reference that references a reference
+    """
+    yield _get_parsed_yaml("reference-reference-reference.yaml")

--- a/tests/fixtures/reference-reference-reference.yaml
+++ b/tests/fixtures/reference-reference-reference.yaml
@@ -1,0 +1,32 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Reference Reference Reference
+paths:
+  '/test':
+    post:
+      requestBody:
+        description: ''
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                example:
+                  $ref: '#/components/schemas/Example/properties/reference'
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Example:
+      type: object
+      properties:
+        reference:
+          $ref: '#/components/schemas/Example/properties/real'
+        real:
+          type: string

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -153,3 +153,11 @@ def test_openapi_3_1_0_references(with_openapi_310_references):
     assert extended_ref._proxy == original_path
     assert isinstance(extended_ref._original_ref, Reference)
     assert extended_ref._original_ref != normal_ref._original_ref
+
+
+def test_reference_referencing_reference(with_reference_referencing_reference):
+    spec = OpenAPI(with_reference_referencing_reference)
+
+    assert type(spec.components.schemas["Example"].properties["real"]) == Schema, "Real property was not a schema?"
+    assert type(spec.components.schemas["Example"].properties["reference"]) == Schema, "Reference property was not resolved"
+    assert type(spec.paths["/test"].post.requestBody.content["application/json"].schema.properties["example"]) == Schema, "Reference reference was not resolved"

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -158,6 +158,6 @@ def test_openapi_3_1_0_references(with_openapi_310_references):
 def test_reference_referencing_reference(with_reference_referencing_reference):
     spec = OpenAPI(with_reference_referencing_reference)
 
-    assert type(spec.components.schemas["Example"].properties["real"]) == Schema, "Real property was not a schema?"
-    assert type(spec.components.schemas["Example"].properties["reference"]) == Schema, "Reference property was not resolved"
-    assert type(spec.paths["/test"].post.requestBody.content["application/json"].schema.properties["example"]) == Schema, "Reference reference was not resolved"
+    assert isinstance(spec.components.schemas["Example"].properties["real"], Schema), "Real property was not a schema?"
+    assert isinstance(spec.components.schemas["Example"].properties["reference"], Schema), "Reference property was not resolved"
+    assert isinstance(spec.paths["/test"].post.requestBody.content["application/json"].schema.properties["example"], Schema), "Reference reference was not resolved"


### PR DESCRIPTION
Related to https://github.com/linode/linode-cli/pull/423

In the above, it was discovered that a reference in a `requestBody`
schema that references a reference in `components.schema` will see the
`Reference` object once resolution is complete, which is unexpected; it
should see the final `Schema`.

This change resolves all references in `components` before resolving
them in the rest of the spec to ensure they are always done in the
proper order.
