### PR TITLE
fix: Support extensions when merging references

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -58,6 +58,7 @@ class Schema(ObjectBase):
         "contentEncoding",
         "contentMediaType",
         "contentSchema",
+        "extensions",
         "_model_type",
         "_request_model_type",
         "_resolved_allOfs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,3 +235,11 @@ def with_all_default_types():
     Provides a spec with defaults defined in various schemas of all types
     """
     yield _get_parsed_yaml("with_all_default_types.yaml")
+
+
+@pytest.fixture
+def with_merge_extension():
+    """
+    Provides a spec that merges extensions from a component ref.
+    """
+    yield _get_parsed_yaml("merge-extension.yaml")

--- a/tests/fixtures/merge-extension.yaml
+++ b/tests/fixtures/merge-extension.yaml
@@ -1,0 +1,39 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Contains a POST request that overrides certain fields from a component ref
+paths:
+  /example:
+    post:
+      operationId: addExample
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/Request'
+              properties:
+                bar:
+                  description: Foo
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+
+components:
+  schemas:
+    Request:
+      type: object
+      properties:
+        bar:
+          type: string
+          x-test-extension: test
+    Response:
+      type: object
+      properties:
+        foo:
+          type: string

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -161,12 +161,12 @@ def test_reference_referencing_reference(with_reference_referencing_reference):
     assert isinstance(spec.paths["/test"].post.requestBody.content["application/json"].schema.properties["example"], Schema), "Reference reference was not resolved"
 
 
-def test_reference_merge_extensions(with_merge_allOf):
+def test_reference_merge_extensions(with_merge_extension):
     """
     Tests that a schema with a $ref within the request schema will properly
     merge extensions.
     """
-    spec = OpenAPI(with_merge_allOf)
+    spec = OpenAPI(with_merge_extension)
 
     schema = spec.paths["/example"].post.requestBody.content["application/json"].schema
     assert type(schema.properties["bar"]) == Schema

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -52,11 +52,9 @@ def test_allOf_resolution(petstore_expanded_spec):
     assert "tag" in items.properties
 
     id_prop = items.properties["id"]
-    id_prop = items.properties["id"]
     assert id_prop.type == "integer"
     assert id_prop.format == "int64"
 
-    name = items.properties["name"]
     name = items.properties["name"]
     assert name.type == "string"
 
@@ -161,3 +159,16 @@ def test_reference_referencing_reference(with_reference_referencing_reference):
     assert isinstance(spec.components.schemas["Example"].properties["real"], Schema), "Real property was not a schema?"
     assert isinstance(spec.components.schemas["Example"].properties["reference"], Schema), "Reference property was not resolved"
     assert isinstance(spec.paths["/test"].post.requestBody.content["application/json"].schema.properties["example"], Schema), "Reference reference was not resolved"
+
+
+def test_reference_merge_extensions(with_merge_allOf):
+    """
+    Tests that a schema with a $ref within the request schema will properly
+    merge extensions.
+    """
+    spec = OpenAPI(with_merge_allOf)
+
+    schema = spec.paths["/example"].post.requestBody.content["application/json"].schema
+    assert type(schema.properties["bar"]) == Schema
+    assert schema.properties["bar"].type == "string"
+    assert schema.properties["bar"].extensions["test-extension"] == "test"


### PR DESCRIPTION
This change adds support for merging extensions through the [Schema._merge(...)](https://github.com/Dorthu/openapi3/blob/master/openapi3/schemas.py#LL204C1-L204C1) method and adds a corresponding test.

This change addresses an issue that caused the [x-linode-cli-format extension](https://github.com/linode/linode-api-docs/blob/development/openapi.yaml#LL20854C1-L20854C13) to not be inherited in the [Firewall Rules Update](https://github.com/linode/linode-api-docs/blob/development/openapi.yaml#L13533) and the [Firewall Create](https://github.com/linode/linode-api-docs/blob/development/openapi.yaml#L12988) endpoints.

Please let me know if you have any feedback :slightly_smiling_face: 