### PR TITLE
Set 'default' field type as anything possible

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -88,7 +88,7 @@ class Schema(ObjectBase):
         self.additionalProperties = self._get("additionalProperties", [bool, dict])
         self.description = self._get("description", str)
         self.format = self._get("format", str)
-        self.default = self._get("default", TYPE_LOOKUP.get(self.type, str))  # TODO - str as a default?
+        self.default = self._get("default", [list, dict, str, int, float, bool])  # TODO - str as a default?
         self.nullable = self._get("nullable", bool)
         self.discriminator = self._get("discriminator", dict)  # 'Discriminator'
         self.readOnly = self._get("readOnly", bool)


### PR DESCRIPTION
Default can be anything.

Same problem than MR #104 : unable to write UT, the following error occurs:

`============================================================================================== ERRORS ===============================================================================================
______________________________________________________________________________ ERROR collecting tests/fastapi_test.py _______________________________________________________________________________
tests/fastapi_test.py:15: in <module>
    from api.main import app
tests/api/main.py:59: in <module>
    def getPet(pet_id: int = Query(..., alias='petId')) -> Pets:
../.local/lib/python3.10/site-packages/fastapi/routing.py:706: in decorator
    self.add_api_route(
../.local/lib/python3.10/site-packages/fastapi/routing.py:645: in add_api_route
    route = route_class(
../.local/lib/python3.10/site-packages/fastapi/routing.py:491: in __init__
    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
../.local/lib/python3.10/site-packages/fastapi/dependencies/utils.py:261: in get_dependant
    type_annotation, depends, param_field = analyze_param(
../.local/lib/python3.10/site-packages/fastapi/dependencies/utils.py:410: in analyze_param
    assert isinstance(field_info, params.Path), (
E   AssertionError: Cannot use `Query` for path param 'pet_id'
====================================================================================== short test summary info ======================================================================================
ERROR tests/fastapi_test.py - AssertionError: Cannot use `Query` for path param 'pet_id'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================================================================= 1 error in 0.49s ==========================================================================================`