### PR TITLE
fix: Recursively resolve allOfs for schema objects

### DIFF
--- a/openapi3/schemas.py
+++ b/openapi3/schemas.py
@@ -202,6 +202,9 @@ class Schema(ObjectBase):
                 if isinstance(c, Schema):
                     self._merge(c)
 
+        # Recursively merge allOfs for children
+        super()._resolve_allOfs()
+
     def _merge(self, other):
         """
         Merges ``other`` into this schema, preferring to use the values in ``other``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,3 +243,10 @@ def with_merge_extension():
     Provides a spec that merges extensions from a component ref.
     """
     yield _get_parsed_yaml("merge-extension.yaml")
+
+@pytest.fixture
+def with_deeply_nested_allof():
+    """
+    Provides a spec with a $ref under a schema defined in an allOf
+    """
+    yield _get_parsed_yaml("deeply-nested-allOf.yaml")

--- a/tests/fixtures/deeply-nested-allOf.yaml
+++ b/tests/fixtures/deeply-nested-allOf.yaml
@@ -1,0 +1,32 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: This has an allOf nested within a Schema property.
+paths:
+  /example:
+    get:
+      operationId: hasDeeplyNestedAllOfRef
+      responses:
+        '200':
+          description: Example
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  foobar:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/Data'
+                        - properties:
+                            foo:
+                              type: integer
+
+components:
+  schemas:
+    Data:
+      type: object
+      properties:
+        bar:
+          type: string

--- a/tests/ref_test.py
+++ b/tests/ref_test.py
@@ -172,3 +172,22 @@ def test_reference_merge_extensions(with_merge_extension):
     assert type(schema.properties["bar"]) == Schema
     assert schema.properties["bar"].type == "string"
     assert schema.properties["bar"].extensions["test-extension"] == "test"
+
+def test_resolving_deeply_nested_allof(with_deeply_nested_allof):
+    """
+    Tests that a schema with a $ref nested within a schema defined in an allOf
+    parses correctly
+    """
+    spec = OpenAPI(with_deeply_nested_allof)
+
+    schema = spec.paths['/example'].get.responses['200'].content['application/json'].schema
+
+    assert type(schema.properties['foobar']) == Schema
+    assert schema.properties['foobar'].type == 'array'
+    assert type(schema.properties['foobar'].items) == Schema
+
+    assert "foo" in schema.properties['foobar'].items.properties
+    assert schema.properties['foobar'].items.properties["foo"].type == "integer"
+
+    assert "bar" in schema.properties['foobar'].items.properties
+    assert schema.properties['foobar'].items.properties["bar"].type == "string"


### PR DESCRIPTION
This change updates the `Schema.resolve_allOfs()` override to recursively resolve `allOfs` for all children objects. This is necessary as allOfs would not previously be parsed in nested Schema objects.

For example, [this segment](https://github.com/linode/linode-api-docs/blob/development/openapi.yaml#L6408-L6413) from the Linode OpenAPI spec would not be parsed correctly because it is nested in `properties.automatic.items`.