### PR TITLE
bug-fix: components/requestBody --> components/requestBodies

### DIFF
--- a/openapi3/components.py
+++ b/openapi3/components.py
@@ -28,7 +28,7 @@ class Components(ObjectBase):
         """
         self.examples = self._get("examples", ["Example", "Reference"], is_map=True)
         self.parameters = self._get("parameters", ["Parameter", "Reference"], is_map=True)
-        self.requestBodies = self._get("requestBody", ["RequestBody", "Reference"], is_map=True)
+        self.requestBodies = self._get("requestBodies", ["RequestBody", "Reference"], is_map=True)
         self.responses = self._get("responses", ["Response", "Reference"], is_map=True)
         self.schemas = self._get("schemas", ["Schema", "Reference"], is_map=True)
         self.securitySchemes = self._get("securitySchemes", ["SecurityScheme", "Reference"], is_map=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,3 +250,10 @@ def with_deeply_nested_allof():
     Provides a spec with a $ref under a schema defined in an allOf
     """
     yield _get_parsed_yaml("deeply-nested-allOf.yaml")
+
+@pytest.fixture
+def ref_request_bodies():
+    """
+    Provides a spec with a $ref to a requestBodies definition
+    """
+    yield _get_parsed_yaml("ref-request-bodies.yaml")

--- a/tests/fixtures/ref-request-bodies.yaml
+++ b/tests/fixtures/ref-request-bodies.yaml
@@ -1,0 +1,47 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    post:
+      summary: Add a new pet
+      requestBody:
+        $ref: "#/components/requestBodies/PetBody"
+      responses:
+        "200":
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+  requestBodies:
+    PetBody:
+      description: A JSON object containing pet information
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"

--- a/tests/parsing_test.py
+++ b/tests/parsing_test.py
@@ -176,3 +176,13 @@ def test_schema_default_types(with_all_default_types):
     assert schema.properties["str"].default == "test"
     assert schema.properties["bool"].default == True
     assert schema.properties["float"].default == 0.1
+
+
+def test_request_bodies_ref(ref_request_bodies):
+    """
+    Tests that refs to components/requestBodies can be resolved
+    """
+    spec = OpenAPI(ref_request_bodies, validate=True)
+    error_messages = [getattr(error, "message") for error in spec.errors()]
+    found_errors = bool(error_messages)
+    assert not found_errors, error_messages


### PR DESCRIPTION
Valid components/requestBodies `$ref`s do not currently parse because there is a typo in `components.py`. You can reproduce the error with the added test file `ref-request-bodies.yaml` in this PR.

This PR fixes the typo and adds the test file for coverage.