### PR TITLE
prevent UnboundLocalError if the user did not provide a request body

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -268,6 +268,7 @@ class Operation(ObjectBase):
 
     def _request_handle_body(self, data):
         if "application/json" in self.requestBody.content:
+            body = {}
             if isinstance(data, dict) or isinstance(data, list):
                 body = json.dumps(data)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "…/openapi/client/client.py", line 33, in <module>
    result = api.call_post_greeting(parameters={'name': 'foo'})
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "…/openapi/venv/lib64/python3.12/site-packages/openapi3/openapi.py", line 256, in __call__
    return self.operation(self.base_url, *args, security=self.security, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "…/openapi/venv/lib64/python3.12/site-packages/openapi3/paths.py", line 337, in request
    self._request_handle_body(data)
  File "…/openapi/venv/lib64/python3.12/site-packages/openapi3/paths.py", line 282, in _request_handle_body
    self._request.data = body
                         ^^^^
UnboundLocalError: cannot access local variable 'body' where it is not associated with a value
```

Even though the request might still be invalid with the modification, at least there is a chance that the server response contains some helpful information.

For example a simple Connexion app responds with: HTTP status code 400 / "Request body must not be empty".

The openapi3 client used:
```python
result = api.call_post_greeting(parameters={'name': 'foo'})
```

instead of 
```python
result = api.call_post_greeting(parameters={'name': 'foo'}, data={})
```
