### PR TITLE
use `session.prepare_request()` to create the prepared request (#116)

### DIFF
--- a/openapi3/paths.py
+++ b/openapi3/paths.py
@@ -341,7 +341,8 @@ class Operation(ObjectBase):
             session = self._session
 
         # send the prepared request
-        result = session.send(self._request.prepare(), verify=verify)
+        prepared_request = session.prepare_request(self._request)
+        result = session.send(prepared_request, verify=verify)
 
         # spec enforces these are strings
         status_code = str(result.status_code)


### PR DESCRIPTION
This is necessary so that session hooks will be triggered for this request.
