### PR TITLE
openapi.py: let base_url be a object scope variable

### DIFF
--- a/openapi3/openapi.py
+++ b/openapi3/openapi.py
@@ -16,6 +16,7 @@ class OpenAPI(ObjectBase):
         "openapi",
         "info",
         "servers",
+        "base_url",
         "paths",
         "components",
         "security",
@@ -178,6 +179,7 @@ class OpenAPI(ObjectBase):
         self.paths = self._get("paths", ["Path", "Reference"], is_map=True)
         self.security = self._get("security", ["SecurityRequirement"], is_list=True)
         self.servers = self._get("servers", ["Server"], is_list=True)
+        self.base_url = self.servers[0].url
         self.tags = self._get("tags", ["Tag"], is_list=True)
 
         # now that we've parsed _all_ the data, resolve all references; start with
@@ -199,9 +201,8 @@ class OpenAPI(ObjectBase):
                   configuration.
         :rtype: OperationCallable
         """
-        base_url = self.servers[0].url
 
-        return OperationCallable(operation, base_url, self._security, self._ssl_verify, self._session)
+        return OperationCallable(operation, self.base_url, self._security, self._ssl_verify, self._session)
 
     def __getattribute__(self, attr):
         """


### PR DESCRIPTION
As defined in the OpenAPI standard the Server Object contain an URL, that can be both absolute and relative.
By placing base_url as a object scope variable the correct full URL can be injected after creating an OpenAPI object, e.g:

api = OpenAPI(json.load(file))
api.base_url = 'https://x.x.x.x' + api.base_url